### PR TITLE
fix(itemservice): instance fields and TOCTOU fix

### DIFF
--- a/skills/dotnet-minimal-api/SKILL.md
+++ b/skills/dotnet-minimal-api/SKILL.md
@@ -6,7 +6,7 @@ description:
 user-invocable: true
 argument-hint: "create a new .NET Minimal API project"
 metadata:
-  version: 1.0.4
+  version: 1.0.5
   author: Michael Astrauckas
   tags: dotnet, minimal-api, csharp
   created: "2026-02-28"

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Services/ItemService.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Services/ItemService.cs
@@ -2,13 +2,13 @@ namespace MyMinimalWebApp.Api.Services;
 
 public class ItemService : IItemService
 {
-    private static readonly List<ItemDto> _items = new()
-    {
+    private readonly List<ItemDto> _items =
+    [
         new ItemDto(1, "Item 1", "First item"),
         new ItemDto(2, "Item 2", "Second item"),
-    };
+    ];
 
-    private static int _nextId = 3;
+    private int _nextId = 3;
 
     public Task<IEnumerable<ItemDto>> GetAllAsync() =>
         Task.FromResult(_items.AsEnumerable());
@@ -30,12 +30,11 @@ public class ItemService : IItemService
         int id,
         ItemDto item)
     {
-        ItemDto? existingItem = _items.FirstOrDefault(x => x.Id == id);
-        if (existingItem is null)
+        int index = _items.FindIndex(x => x.Id == id);
+        if (index < 0)
             return Task.FromResult<ItemDto?>(null);
 
         var updatedItem = new ItemDto(id, item.Name, item.Description);
-        int index = _items.FindIndex(x => x.Id == id);
         _items[index] = updatedItem;
         return Task.FromResult<ItemDto?>(updatedItem);
     }


### PR DESCRIPTION
## Changes

- **Static → instance fields**: \_items\ and \_nextId\ were static, causing shared state across all singleton instances, race conditions under concurrent load, and test isolation failures. Removed \static\ keyword.
- **TOCTOU fix in \UpdateAsync\**: replaced double-lookup (\FirstOrDefault\ then \FindIndex\) with a single \FindIndex\ call.
- Bump version to 1.0.5