### PR TITLE
feat(template): port selection, Kestrel config, ForwardedHeaders, client IP logging

### DIFF
--- a/skills/dotnet-minimal-api/SKILL.md
+++ b/skills/dotnet-minimal-api/SKILL.md
@@ -30,9 +30,9 @@ When asked to create a new project, **ask the user the following questions befor
    `<SolutionName>.Api`)
 3. **Output directory** — where should the project be created? (defaults to the current working
    directory)
-4. **HTTP port** — generate a random port in the range 5000–5999 and offer it as the suggestion.
+4. **HTTP port** — generate a random port in the range 1024–65535 and offer it as the suggestion.
    Present it as a choice alongside a freeform option so the user can accept or enter their own.
-   Example prompt: *"Suggested HTTP port: 5743. Use this or enter your own."*
+   Example prompt: *"Suggested HTTP port: 42817. Use this or enter your own."*
 
 Once you have the answers:
 

--- a/skills/dotnet-minimal-api/SKILL.md
+++ b/skills/dotnet-minimal-api/SKILL.md
@@ -30,10 +30,9 @@ When asked to create a new project, **ask the user the following questions befor
    `<SolutionName>.Api`)
 3. **Output directory** — where should the project be created? (defaults to the current working
    directory)
-4. **HTTP port** — generate a random port in the IANA dynamic/private range 49152–65535 and offer
-   it as the suggestion. Present it as a choice alongside a freeform option so the user can accept
-   or enter their own.
-   Example prompt: *"Suggested HTTP port: 52817. Use this or enter your own."*
+4. **HTTP port** — generate a random port in the range 8000–8999 and offer it as the suggestion.
+   Present it as a choice alongside a freeform option so the user can accept or enter their own.
+   Example prompt: *"Suggested HTTP port: 8432. Use this or enter your own."*
 
 Once you have the answers:
 

--- a/skills/dotnet-minimal-api/SKILL.md
+++ b/skills/dotnet-minimal-api/SKILL.md
@@ -58,7 +58,7 @@ Once you have the answers:
 - Rename `tests/MyMinimalWebApp.Api.UnitTests/` → `tests/<ProjectName>.UnitTests/`
 - Update all namespace references in test projects from `MyMinimalWebApp.Api` → `<ProjectName>`
 - Replace `Item`/`Items` with the appropriate domain entity name if provided
-- Replace the HTTP port `5262` with `<HttpPort>` in:
+- Replace the HTTP port `5262` with `<HttpPort>` and the HTTPS port `7105` with `<HttpPort + 1>` in:
   - `src/<ProjectName>/Properties/launchSettings.json` (both `http` and `https` profiles)
   - `http-files/items.http`
   - `http-files/health.http`

--- a/skills/dotnet-minimal-api/SKILL.md
+++ b/skills/dotnet-minimal-api/SKILL.md
@@ -6,7 +6,7 @@ description:
 user-invocable: true
 argument-hint: "create a new .NET Minimal API project"
 metadata:
-  version: 1.0.7
+  version: 1.0.8
   author: Michael Astrauckas
   tags: dotnet, minimal-api, csharp
   created: "2026-02-28"
@@ -60,6 +60,7 @@ Once you have the answers:
 - Replace `Item`/`Items` with the appropriate domain entity name if provided
 - Replace the HTTP port `5262` with `<HttpPort>` and the HTTPS port `7105` with `<HttpPort + 1>` in:
   - `src/<ProjectName>/Properties/launchSettings.json` (both `http` and `https` profiles)
+  - `src/<ProjectName>/appsettings.json` (both `Kestrel.Endpoints.Http.Url` and `Kestrel.Endpoints.Https.Url`)
   - `http-files/items.http`
   - `http-files/health.http`
 

--- a/skills/dotnet-minimal-api/SKILL.md
+++ b/skills/dotnet-minimal-api/SKILL.md
@@ -6,7 +6,7 @@ description:
 user-invocable: true
 argument-hint: "create a new .NET Minimal API project"
 metadata:
-  version: 1.0.6
+  version: 1.0.7
   author: Michael Astrauckas
   tags: dotnet, minimal-api, csharp
   created: "2026-02-28"
@@ -30,6 +30,9 @@ When asked to create a new project, **ask the user the following questions befor
    `<SolutionName>.Api`)
 3. **Output directory** — where should the project be created? (defaults to the current working
    directory)
+4. **HTTP port** — generate a random port in the range 5000–5999 and offer it as the suggestion.
+   Present it as a choice alongside a freeform option so the user can accept or enter their own.
+   Example prompt: *"Suggested HTTP port: 5743. Use this or enter your own."*
 
 Once you have the answers:
 
@@ -48,6 +51,10 @@ Once you have the answers:
 - Rename `tests/MyMinimalWebApp.Api.UnitTests/` → `tests/<ProjectName>.UnitTests/`
 - Update all namespace references in test projects from `MyMinimalWebApp.Api` → `<ProjectName>`
 - Replace `Item`/`Items` with the appropriate domain entity name if provided
+- Replace the HTTP port `5262` with `<HttpPort>` in:
+  - `src/<ProjectName>/Properties/launchSettings.json` (both `http` and `https` profiles)
+  - `http-files/items.http`
+  - `http-files/health.http`
 
 ## Template
 

--- a/skills/dotnet-minimal-api/SKILL.md
+++ b/skills/dotnet-minimal-api/SKILL.md
@@ -30,9 +30,10 @@ When asked to create a new project, **ask the user the following questions befor
    `<SolutionName>.Api`)
 3. **Output directory** — where should the project be created? (defaults to the current working
    directory)
-4. **HTTP port** — generate a random port in the range 1024–65535 and offer it as the suggestion.
-   Present it as a choice alongside a freeform option so the user can accept or enter their own.
-   Example prompt: *"Suggested HTTP port: 42817. Use this or enter your own."*
+4. **HTTP port** — generate a random port in the IANA dynamic/private range 49152–65535 and offer
+   it as the suggestion. Present it as a choice alongside a freeform option so the user can accept
+   or enter their own.
+   Example prompt: *"Suggested HTTP port: 52817. Use this or enter your own."*
 
 Once you have the answers:
 

--- a/skills/dotnet-minimal-api/SKILL.md
+++ b/skills/dotnet-minimal-api/SKILL.md
@@ -101,8 +101,8 @@ template/
         ItemService.cs
       Properties/
         launchSettings.json                 ← Kestrel profiles, launchBrowser: false
-      appsettings.json                      ← Serilog, Cors, ConnectionStrings, Auth, KeyVault
-      appsettings.Development.json          ← Debug log level override
+      appsettings.json                      ← Serilog, Kestrel, Cors, ConnectionStrings, Auth, KeyVault
+      appsettings.Development.json          ← DetailedErrors, Debug log level override
       appsettings.Production.json           ← Warning log level override
   tests/
     MyMinimalWebApp.Api.IntegrationTests/

--- a/skills/dotnet-minimal-api/SKILL.md
+++ b/skills/dotnet-minimal-api/SKILL.md
@@ -30,9 +30,16 @@ When asked to create a new project, **ask the user the following questions befor
    `<SolutionName>.Api`)
 3. **Output directory** — where should the project be created? (defaults to the current working
    directory)
-4. **HTTP port** — generate a random port in the range 8000–8999 and offer it as the suggestion.
-   Present it as a choice alongside a freeform option so the user can accept or enter their own.
-   Example prompt: *"Suggested HTTP port: 8432. Use this or enter your own."*
+4. **HTTP port** — generate a random port in the range 8000–8999 by running the appropriate command
+   for the user's platform:
+   - **Windows**: `Get-Random -Minimum 8000 -Maximum 8999`
+   - **Linux**: `shuf -i 8000-8999 -n 1`
+   - **macOS**: `jot -r 1 8000 8999`
+   - **Fallback** (any platform): `python3 -c "import random; print(random.randint(8000, 8999))"` or
+     `node -e "console.log(Math.floor(Math.random()*1000)+8000)"`
+
+   Present the generated port as a choice alongside a freeform option so the user can accept or
+   enter their own. Example prompt: *"Suggested HTTP port: 8432. Use this or enter your own."*
 
 Once you have the answers:
 

--- a/skills/dotnet-minimal-api/SKILL.md
+++ b/skills/dotnet-minimal-api/SKILL.md
@@ -6,7 +6,7 @@ description:
 user-invocable: true
 argument-hint: "create a new .NET Minimal API project"
 metadata:
-  version: 1.0.8
+  version: 1.0.7
   author: Michael Astrauckas
   tags: dotnet, minimal-api, csharp
   created: "2026-02-28"

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/AppConfiguration.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/AppConfiguration.cs
@@ -10,7 +10,13 @@ public static class AppConfigurationExtensions
             app.UseForwardedHeaders();
 
             app.UseMiddleware<ExceptionMiddleware>();
-            app.UseSerilogRequestLogging();
+            app.UseSerilogRequestLogging(options =>
+            {
+                options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
+                {
+                    diagnosticContext.Set("ClientIp", httpContext.Connection.RemoteIpAddress);
+                };
+            });
 
             // ORDER MATTERS: UseCors must come before UseAuthentication/UseAuthorization
             // so CORS preflight requests are handled before auth middleware runs.

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/AppConfiguration.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/AppConfiguration.cs
@@ -6,6 +6,9 @@ public static class AppConfigurationExtensions
     {
         public void ConfigureApp()
         {
+            // Must be first — rewrites HttpContext with real client IP and scheme from proxy headers
+            app.UseForwardedHeaders();
+
             app.UseMiddleware<ExceptionMiddleware>();
             app.UseSerilogRequestLogging();
 

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/BuilderConfiguration.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/BuilderConfiguration.cs
@@ -12,6 +12,7 @@ public static class BuilderConfigurationExtensions
             builder.RegisterRateLimiting();
             builder.RegisterHealthChecks();
             builder.RegisterProblemDetails();
+            builder.RegisterForwardedHeaders();
             builder.RegisterLogging();
             builder.RegisterDatabase();
             builder.RegisterValidation();
@@ -93,6 +94,16 @@ public static class BuilderConfigurationExtensions
         }
 
         public void RegisterProblemDetails() => builder.Services.AddProblemDetails();
+
+        public void RegisterForwardedHeaders()
+        {
+            builder.Services.Configure<ForwardedHeadersOptions>(options =>
+            {
+                options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+                // Restrict to known proxy networks in production for security.
+                // By default, only loopback proxies are trusted.
+            });
+        }
 
         public void RegisterValidation() => builder.Services.AddValidation();
 

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/GlobalUsings.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/GlobalUsings.cs
@@ -1,4 +1,5 @@
 global using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+global using Microsoft.AspNetCore.HttpOverrides;
 global using Microsoft.AspNetCore.Http.HttpResults;
 global using Microsoft.AspNetCore.RateLimiting;
 global using Microsoft.Extensions.DependencyInjection;

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.Development.json
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.Development.json
@@ -1,4 +1,5 @@
 {
+  "DetailedErrors": true,
   "Serilog": {
     "MinimumLevel": {
       "Default": "Debug",

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.json
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.json
@@ -22,6 +22,16 @@
     ],
     "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ]
   },
+  "Kestrel": {
+    "Endpoints": {
+      "Http": {
+        "Url": "http://[::]:5262"
+      },
+      "Https": {
+        "Url": "https://[::]:7105"
+      }
+    }
+  },
   "AllowedHosts": "*",
   "Cors": {
     "AllowedOrigins": [ "http://localhost:4200" ]


### PR DESCRIPTION
## Changes

### Scaffolding
- Added question 4: generate a random HTTP port (8000–8999) using platform-native commands (PowerShell, \shuf\, \jot\) with Python/Node fallback. User can accept or enter their own.
- Scaffold step replaces HTTP port \5262\ and HTTPS port \7105\ (derived as \HttpPort+1\) in \launchSettings.json\, \ppsettings.json\, \items.http\, and \health.http\

### Template
- Added \Kestrel.Endpoints\ to \ppsettings.json\ — explicit port config for containers/production where \launchSettings.json\ is absent
- Added \DetailedErrors: true\ to \ppsettings.Development.json\
- Added \UseForwardedHeaders\ (first in pipeline) + \ForwardedHeadersOptions\ registration — real client IP and scheme when behind nginx or Kubernetes ingress
- Enriched \UseSerilogRequestLogging\ with \ClientIp\ from \HttpContext.Connection.RemoteIpAddress\
- Updated structure diagram to reflect new appsettings contents
- Bump version to 1.0.7