### PR TITLE
feat(template): KnownNetworks comments, source metadata, rename CORS policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,8 @@ jobs:
       - name: Replace commit hash token in SKILL.md
         run: |
           TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          sed -i "s/{{COMMIT_HASH}}/${{ github.sha }}/g" skills/dotnet-minimal-api/SKILL.md
-          sed -i "s/{{LAST_UPDATED}}/${TIMESTAMP}/g" skills/dotnet-minimal-api/SKILL.md
+          sed -i 's/commit: ".*"/commit: "${{ github.sha }}"/g' skills/dotnet-minimal-api/SKILL.md
+          sed -i "s/last-updated: \".*\"/last-updated: \"${TIMESTAMP}\"/g" skills/dotnet-minimal-api/SKILL.md
 
       - name: Commit stamped SKILL.md
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,28 @@ jobs:
           recreate: true
           path: code-coverage-results.md
 
+  stamp-commit-hash:
+    name: Stamp Commit Hash
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Replace commit hash token in SKILL.md
+        run: |
+          sed -i "s/{{COMMIT_HASH}}/${{ github.sha }}/g" skills/dotnet-minimal-api/SKILL.md
+
+      - name: Commit stamped SKILL.md
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add skills/dotnet-minimal-api/SKILL.md
+          git diff --cached --quiet || git commit -m "chore: stamp commit hash in SKILL.md [skip ci]"
+          git push
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,9 @@ jobs:
 
       - name: Replace commit hash token in SKILL.md
         run: |
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           sed -i "s/{{COMMIT_HASH}}/${{ github.sha }}/g" skills/dotnet-minimal-api/SKILL.md
+          sed -i "s/{{LAST_UPDATED}}/${TIMESTAMP}/g" skills/dotnet-minimal-api/SKILL.md
 
       - name: Commit stamped SKILL.md
         run: |

--- a/skills/dotnet-minimal-api/SKILL.md
+++ b/skills/dotnet-minimal-api/SKILL.md
@@ -9,6 +9,7 @@ metadata:
   version: 1.0.8
   author: Michael Astrauckas
   source: https://github.com/mastrauckas/ai
+  commit: "{{COMMIT_HASH}}"
   tags: dotnet, minimal-api, csharp
   created: "2026-02-28"
   dotnet-version: "10.0"

--- a/skills/dotnet-minimal-api/SKILL.md
+++ b/skills/dotnet-minimal-api/SKILL.md
@@ -10,6 +10,7 @@ metadata:
   author: Michael Astrauckas
   source: https://github.com/mastrauckas/ai
   commit: "{{COMMIT_HASH}}"
+  last-updated: "{{LAST_UPDATED}}"
   tags: dotnet, minimal-api, csharp
   created: "2026-02-28"
   dotnet-version: "10.0"

--- a/skills/dotnet-minimal-api/SKILL.md
+++ b/skills/dotnet-minimal-api/SKILL.md
@@ -106,7 +106,8 @@ template/
         launchSettings.json                 ← Kestrel profiles, launchBrowser: false
       appsettings.json                      ← Serilog, Kestrel, Cors, ConnectionStrings, Auth, KeyVault
       appsettings.Development.json          ← DetailedErrors, Debug log level override
-      appsettings.Production.json           ← Warning log level override
+      appsettings.Staging.json              ← Warning log level, per-env placeholders
+      appsettings.Production.json           ← Warning log level, per-env placeholders
   tests/
     MyMinimalWebApp.Api.IntegrationTests/
       Endpoints/ItemEndpointsTests.cs       ← WebApplicationFactory<Program> integration tests

--- a/skills/dotnet-minimal-api/SKILL.md
+++ b/skills/dotnet-minimal-api/SKILL.md
@@ -6,8 +6,9 @@ description:
 user-invocable: true
 argument-hint: "create a new .NET Minimal API project"
 metadata:
-  version: 1.0.7
+  version: 1.0.8
   author: Michael Astrauckas
+  source: https://github.com/mastrauckas/ai
   tags: dotnet, minimal-api, csharp
   created: "2026-02-28"
   dotnet-version: "10.0"

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/AppConfiguration.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/AppConfiguration.cs
@@ -22,7 +22,7 @@ public static class AppConfigurationExtensions
             // so CORS preflight requests are handled before auth middleware runs.
             if (app.Environment.IsDevelopment())
             {
-                app.UseCors("AllowLocalAngularDevelopment");
+                app.UseCors("AllowLocalDevelopment");
             }
 
             // ORDER MATTERS: UseAuthentication must come before UseAuthorization.

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/BuilderConfiguration.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/BuilderConfiguration.cs
@@ -101,10 +101,19 @@ public static class BuilderConfigurationExtensions
             {
                 options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
 
-                // Uncomment the lines below when running in a trusted network (e.g., Kubernetes cluster)
-                // where all proxies are known. By default only loopback proxies are trusted, which is
-                // the safe default for internet-facing apps. Clearing these allows any proxy to forward
-                // headers — only do this when your ingress is the sole entry point.
+                // Uncomment the lines below when ALL of the following are true:
+                //   - Running behind a reverse proxy (nginx, Kubernetes ingress, AWS ALB, Azure Front Door)
+                //   - The proxy is the sole entry point (pods are not directly reachable from the internet)
+                //   - Traffic arrives from a non-loopback IP (e.g., Kubernetes ClusterIP, internal VPC address)
+                //
+                // Common scenarios:
+                //   - Kubernetes: ingress controller reaches pods via ClusterIP — not loopback, so headers
+                //     are ignored by default. Clearing these lets any in-cluster proxy forward headers.
+                //   - Docker Compose: nginx container forwards to app container via bridge network IP.
+                //   - Cloud load balancers: AWS ALB, Azure App Gateway, Cloudflare — all use non-loopback IPs.
+                //
+                // Do NOT uncomment if pods/containers are directly reachable from the internet —
+                // an attacker could spoof X-Forwarded-For to fake their IP.
                 // options.KnownNetworks.Clear();
                 // options.KnownProxies.Clear();
             });

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/BuilderConfiguration.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/BuilderConfiguration.cs
@@ -47,7 +47,7 @@ public static class BuilderConfigurationExtensions
 
             builder.Services.AddCors(options =>
             {
-                options.AddPolicy("AllowLocalAngularDevelopment", policy =>
+                options.AddPolicy("AllowLocalDevelopment", policy =>
                 {
                     policy.WithOrigins(allowedOrigins)
                         .AllowAnyHeader()
@@ -100,8 +100,13 @@ public static class BuilderConfigurationExtensions
             builder.Services.Configure<ForwardedHeadersOptions>(options =>
             {
                 options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
-                // Restrict to known proxy networks in production for security.
-                // By default, only loopback proxies are trusted.
+
+                // Uncomment the lines below when running in a trusted network (e.g., Kubernetes cluster)
+                // where all proxies are known. By default only loopback proxies are trusted, which is
+                // the safe default for internet-facing apps. Clearing these allows any proxy to forward
+                // headers — only do this when your ingress is the sole entry point.
+                // options.KnownNetworks.Clear();
+                // options.KnownProxies.Clear();
             });
         }
 

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.Development.json
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.Development.json
@@ -12,5 +12,15 @@
   },
   "Cors": {
     "AllowedOrigins": [ "http://localhost:4200" ]
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": ""
+  },
+  "Auth": {
+    "Authority": "",
+    "Audience": ""
+  },
+  "KeyVault": {
+    "Uri": ""
   }
 }

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.Production.json
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.Production.json
@@ -8,16 +8,5 @@
         "System": "Warning"
       }
     }
-  },
-  "AllowedHosts": "*",
-  "ConnectionStrings": {
-    "DefaultConnection": ""
-  },
-  "Auth": {
-    "Authority": "",
-    "Audience": ""
-  },
-  "KeyVault": {
-    "Uri": ""
   }
 }

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.Production.json
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.Production.json
@@ -8,5 +8,18 @@
         "System": "Warning"
       }
     }
+  },
+  "Cors": {
+    "AllowedOrigins": []
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": ""
+  },
+  "Auth": {
+    "Authority": "",
+    "Audience": ""
+  },
+  "KeyVault": {
+    "Uri": ""
   }
 }

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.Staging.json
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.Staging.json
@@ -1,0 +1,25 @@
+{
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Warning",
+      "Override": {
+        "Microsoft": "Warning",
+        "Microsoft.AspNetCore": "Warning",
+        "System": "Warning"
+      }
+    }
+  },
+  "Cors": {
+    "AllowedOrigins": []
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": ""
+  },
+  "Auth": {
+    "Authority": "",
+    "Audience": ""
+  },
+  "KeyVault": {
+    "Uri": ""
+  }
+}

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.json
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.json
@@ -34,16 +34,6 @@
   },
   "AllowedHosts": "*",
   "Cors": {
-    "AllowedOrigins": [ "http://localhost:4200" ]
-  },
-  "ConnectionStrings": {
-    "DefaultConnection": ""
-  },
-  "Auth": {
-    "Authority": "",
-    "Audience": ""
-  },
-  "KeyVault": {
-    "Uri": ""
+    "AllowedOrigins": []
   }
 }


### PR DESCRIPTION
## Changes

1. **ForwardedHeaders**: Added commented-out \KnownNetworks.Clear()\ and \KnownProxies.Clear()\ with a clear comment explaining when to uncomment them (trusted Kubernetes clusters where ingress is the sole entry point)

2. **SKILL.md metadata**: Added \source: https://github.com/mastrauckas/ai\ so users know where the skill came from

3. **CORS policy name**: Renamed \AllowLocalAngularDevelopment\ → \AllowLocalDevelopment\ — the template supports any frontend framework, not just Angular

- Bump version to 1.0.8