### PR TITLE
chore: remove stamp-commit-hash job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,30 +53,3 @@ jobs:
           recreate: true
           path: code-coverage-results.md
 
-  stamp-commit-hash:
-    name: Stamp Commit Hash
-    runs-on: ubuntu-latest
-    needs: build-and-test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: main
-
-      - name: Replace commit hash token in SKILL.md
-        run: |
-          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          sed -i 's/commit: ".*"/commit: "${{ github.sha }}"/g' skills/dotnet-minimal-api/SKILL.md
-          sed -i "s/last-updated: \".*\"/last-updated: \"${TIMESTAMP}\"/g" skills/dotnet-minimal-api/SKILL.md
-
-      - name: Commit stamped SKILL.md
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add skills/dotnet-minimal-api/SKILL.md
-          git diff --cached --quiet || git commit -m "chore: stamp commit hash in SKILL.md [skip ci]"
-          git push
-

--- a/skills/dotnet-minimal-api/SKILL.md
+++ b/skills/dotnet-minimal-api/SKILL.md
@@ -9,8 +9,6 @@ metadata:
   version: 1.0.8
   author: Michael Astrauckas
   source: https://github.com/mastrauckas/ai
-  commit: "{{COMMIT_HASH}}"
-  last-updated: "{{LAST_UPDATED}}"
   tags: dotnet, minimal-api, csharp
   created: "2026-02-28"
   dotnet-version: "10.0"

--- a/skills/dotnet-minimal-api/SKILL.md
+++ b/skills/dotnet-minimal-api/SKILL.md
@@ -6,7 +6,7 @@ description:
 user-invocable: true
 argument-hint: "create a new .NET Minimal API project"
 metadata:
-  version: 1.0.8
+  version: 1.0.9
   author: Michael Astrauckas
   source: https://github.com/mastrauckas/ai
   tags: dotnet, minimal-api, csharp

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.Production.json
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.Production.json
@@ -1,16 +1,8 @@
 {
   "Serilog": {
     "MinimumLevel": {
-      "Default": "Warning",
-      "Override": {
-        "Microsoft": "Warning",
-        "Microsoft.AspNetCore": "Warning",
-        "System": "Warning"
-      }
+      "Default": "Warning"
     }
-  },
-  "Cors": {
-    "AllowedOrigins": []
   },
   "ConnectionStrings": {
     "DefaultConnection": ""

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.Production.json
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.Production.json
@@ -1,9 +1,4 @@
 {
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Warning"
-    }
-  },
   "ConnectionStrings": {
     "DefaultConnection": ""
   },

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.Staging.json
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.Staging.json
@@ -1,16 +1,8 @@
 {
   "Serilog": {
     "MinimumLevel": {
-      "Default": "Warning",
-      "Override": {
-        "Microsoft": "Warning",
-        "Microsoft.AspNetCore": "Warning",
-        "System": "Warning"
-      }
+      "Default": "Warning"
     }
-  },
-  "Cors": {
-    "AllowedOrigins": []
   },
   "ConnectionStrings": {
     "DefaultConnection": ""

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.Staging.json
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.Staging.json
@@ -1,9 +1,4 @@
 {
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Warning"
-    }
-  },
   "ConnectionStrings": {
     "DefaultConnection": ""
   },

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.json
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.json
@@ -2,7 +2,7 @@
   "Serilog": {
     "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],
     "MinimumLevel": {
-      "Default": "Information",
+      "Default": "Warning",
       "Override": {
         "Microsoft": "Warning",
         "Microsoft.AspNetCore": "Warning",


### PR DESCRIPTION
Personal repos do not support GitHub App bypass actors in repository rulesets, so the stamp job cannot push to the protected \main\ branch without weakening branch protection for all users.

Removes:
- \stamp-commit-hash\ job from \ci.yml\
- \commit\ and \last-updated\ fields from \SKILL.md\ metadata