### PR TITLE
refactor: move UseSerilog call into RegisterLogging

### DIFF
--- a/skills/dotnet-minimal-api/SKILL.md
+++ b/skills/dotnet-minimal-api/SKILL.md
@@ -6,7 +6,7 @@ description:
 user-invocable: true
 argument-hint: "create a new .NET Minimal API project"
 metadata:
-  version: 1.0.9
+  version: 1.1.0
   author: Michael Astrauckas
   source: https://github.com/mastrauckas/ai
   tags: dotnet, minimal-api, csharp

--- a/skills/dotnet-minimal-api/SKILL.md
+++ b/skills/dotnet-minimal-api/SKILL.md
@@ -6,7 +6,7 @@ description:
 user-invocable: true
 argument-hint: "create a new .NET Minimal API project"
 metadata:
-  version: 1.1.0
+  version: 1.0.10
   author: Michael Astrauckas
   source: https://github.com/mastrauckas/ai
   tags: dotnet, minimal-api, csharp

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/BuilderConfiguration.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/BuilderConfiguration.cs
@@ -125,6 +125,9 @@ public static class BuilderConfigurationExtensions
 
         public void RegisterLogging()
         {
+            builder.Host.UseSerilog((ctx, config) =>
+                config.ReadFrom.Configuration(ctx.Configuration));
+
             // Serilog is configured via the "Serilog" section in appsettings.json.
             // Active sinks: Console + File (rolling daily, 10-day retention).
             // To add more sinks, install the NuGet package and add to "Using" + "WriteTo" in appsettings.json:

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Program.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Program.cs
@@ -1,6 +1,4 @@
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
-builder.Host.UseSerilog((ctx, config) =>
-    config.ReadFrom.Configuration(ctx.Configuration));
 builder.ConfigureBuilder();
 
 WebApplication app = builder.Build();


### PR DESCRIPTION
Program.cs should only orchestrate startup — configuration belongs in \BuilderConfiguration.RegisterLogging\, where the Serilog sink documentation already lives.