### PR TITLE
refactor: improve test project configuration

### DIFF
--- a/skills/dotnet-minimal-api/SKILL.md
+++ b/skills/dotnet-minimal-api/SKILL.md
@@ -130,8 +130,8 @@ template/
 ## Coding Conventions
 
 - All `using` statements → `GlobalUsings.cs` only
-- Use `var` when type is apparent from the right-hand side (constructor calls, `.ToList()`)
-- Use explicit type when type is not apparent (method return values, async results)
+- Use `var` for all local variables — enforced by `csharp_style_var_elsewhere = true:warning`;
+  explicit types for locals are a build error
 - For method declarations and calls with 2+ parameters: first parameter stays on the same line as
   the method name, each additional parameter on its own line
 - Method chains with 2+ dots → each `.` on its own line

--- a/skills/dotnet-minimal-api/SKILL.md
+++ b/skills/dotnet-minimal-api/SKILL.md
@@ -16,9 +16,11 @@ metadata:
 
 ## Quick Start
 
-1. Ask for the **solution name** and **project name** (see [Scaffolding](#scaffolding-a-new-project))
+1. Ask for the **solution name** and **project name** (see
+   [Scaffolding](#scaffolding-a-new-project))
 2. Copy `template/` into the output directory
-3. Rename all src projects, all test projects, and all namespace references from `MyMinimalWebApp.Api` → `<ProjectName>` (see [Scaffolding](#scaffolding-a-new-project))
+3. Rename all src projects, all test projects, and all namespace references from
+   `MyMinimalWebApp.Api` → `<ProjectName>` (see [Scaffolding](#scaffolding-a-new-project))
 4. Replace `Item`/`Items` with your domain entity name
 5. Run `dotnet test` to verify everything passes
 
@@ -40,7 +42,7 @@ When asked to create a new project, **ask the user the following questions befor
      `node -e "console.log(Math.floor(Math.random()*1000)+8000)"`
 
    Present the generated port as a choice alongside a freeform option so the user can accept or
-   enter their own. Example prompt: *"Suggested HTTP port: 8432. Use this or enter your own."*
+   enter their own. Example prompt: _"Suggested HTTP port: 8432. Use this or enter your own."_
 
 Once you have the answers:
 
@@ -60,8 +62,11 @@ Once you have the answers:
 - Update all namespace references in test projects from `MyMinimalWebApp.Api` → `<ProjectName>`
 - Replace `Item`/`Items` with the appropriate domain entity name if provided
 - Replace the HTTP port `5262` with `<HttpPort>` and the HTTPS port `7105` with `<HttpPort + 1>` in:
+  (Note: the template's ports `5262`/`7105` are default .NET placeholders and do not follow the `+1`
+  convention — the convention only applies to generated ports for new projects.)
   - `src/<ProjectName>/Properties/launchSettings.json` (both `http` and `https` profiles)
-  - `src/<ProjectName>/appsettings.json` (both `Kestrel.Endpoints.Http.Url` and `Kestrel.Endpoints.Https.Url`)
+  - `src/<ProjectName>/appsettings.json` (both `Kestrel.Endpoints.Http.Url` and
+    `Kestrel.Endpoints.Https.Url`)
   - `http-files/items.http`
   - `http-files/health.http`
 
@@ -92,7 +97,8 @@ template/
         ItemEndpoints.cs                    ← 5 CRUD endpoints as private static handlers
       Dtos/
         ItemDto.cs                          ← response DTO
-        ItemRequests.cs                     ← CreateItemRequest, UpdateItemRequest
+        CreateItemRequest.cs                ← create request DTO
+        UpdateItemRequest.cs                ← update request DTO
       Logging/
         Log.cs                              ← [LoggerMessage] source-generated log methods
       Middleware/
@@ -126,7 +132,8 @@ template/
 - All `using` statements → `GlobalUsings.cs` only
 - Use `var` when type is apparent from the right-hand side (constructor calls, `.ToList()`)
 - Use explicit type when type is not apparent (method return values, async results)
-- 2+ parameters → each on its own line
+- For method declarations and calls with 2+ parameters: first parameter stays on the same line as
+  the method name, each additional parameter on its own line
 - Method chains with 2+ dots → each `.` on its own line
 - `TreatWarningsAsErrors = true` + `EnforceCodeStyleInBuild = true` — all style rules enforced at
   build time
@@ -138,17 +145,18 @@ template/
 ### Program.cs
 
 ```csharp
-WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
-builder.Host.UseSerilog((ctx, config) =>
-    config.ReadFrom.Configuration(ctx.Configuration));
+var builder = WebApplication.CreateBuilder(args);
 builder.ConfigureBuilder();
 
-WebApplication app = builder.Build();
+var app = builder.Build();
 app.ConfigureApp();
 app.Run();
 
 public partial class Program { }
 ```
+
+`UseSerilog` is called inside `RegisterLogging()` in `BuilderConfiguration.cs` — do **not** add it
+to `Program.cs`.
 
 ### BuilderConfiguration.cs
 
@@ -215,6 +223,8 @@ public static class AppConfigurationExtensions
     {
         public void ConfigureApp()
         {
+            // Must be first — processes X-Forwarded-For / X-Forwarded-Proto
+            app.UseForwardedHeaders();
             app.UseMiddleware<ExceptionMiddleware>();
             app.UseSerilogRequestLogging();
 
@@ -319,8 +329,10 @@ Server, MongoDB) are documented as comments in `RegisterLogging()` inside `Build
 
 Two test projects:
 
-- **`MyMinimalWebApp.Api.IntegrationTests`** — `WebApplicationFactory<Program>`, tests HTTP endpoints and middleware
-- **`MyMinimalWebApp.Api.UnitTests`** — tests service layer directly with Bogus for test data, NSubstitute for mocks
+- **`MyMinimalWebApp.Api.IntegrationTests`** — `WebApplicationFactory<Program>`, tests HTTP
+  endpoints and middleware
+- **`MyMinimalWebApp.Api.UnitTests`** — tests service layer directly with Bogus for test data,
+  NSubstitute for mocks
 
 `public partial class Program {}` at the bottom of `Program.cs` is required for
 `WebApplicationFactory<Program>`.

--- a/skills/dotnet-minimal-api/template/.editorconfig
+++ b/skills/dotnet-minimal-api/template/.editorconfig
@@ -1,56 +1,153 @@
-root = false
+# top-most EditorConfig file
+root = true
 
 [*.cs]
+# Formatting
+indent_style = space
 indent_size = 4
+insert_final_newline = true
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
 
-# Prefer 'var' when type is apparent
-csharp_style_var_for_built_in_types = false:warning
+# Using directives
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = true
+
+# this. preferences
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
+
+# Newline preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+
+# Braces
+csharp_prefer_braces = true:warning
+
+# var preferences - Use var everywhere except target-typed new()
+csharp_style_var_for_built_in_types = true:warning
 csharp_style_var_when_type_is_apparent = true:warning
-csharp_style_var_elsewhere = false:warning
+csharp_style_var_elsewhere = true:warning
 
-# Prefer expression bodies for simple methods and properties
+# Object creation preferences - Use target-typed new()
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+
+# Expression body preferences
 csharp_style_expression_bodied_methods = when_on_single_line:suggestion
 csharp_style_expression_bodied_properties = true:warning
 
-# Prefer modern patterns
+# Modern pattern preferences
 csharp_prefer_simple_using_statement = true:warning
 csharp_style_pattern_matching_over_is_with_cast_check = true:warning
 csharp_style_pattern_matching_over_as_with_null_check = true:warning
 csharp_style_prefer_null_check_over_type_check = true:warning
 csharp_style_prefer_switch_expression = true:warning
 
-# Braces
-csharp_prefer_braces = when_multiline:warning
-
 # Namespace style
 csharp_style_namespace_declarations = file_scoped:warning
 
-# New line preferences
-csharp_new_line_before_open_brace = all
-csharp_new_line_before_else = true
-csharp_new_line_before_catch = true
-csharp_new_line_before_finally = true
-
-# Don't use this. prefix
-dotnet_style_qualification_for_field = false:warning
-dotnet_style_qualification_for_property = false:warning
-dotnet_style_qualification_for_method = false:warning
-dotnet_style_qualification_for_event = false:warning
-
-# Prefer language keywords over framework type names
+# Predefined type preferences (use int not Int32, string not String, etc.)
 dotnet_style_predefined_type_for_locals_parameters_members = true:warning
 dotnet_style_predefined_type_for_member_access = true:warning
 
-# Prefer object/collection initializers
+# Initializer preferences
 dotnet_style_object_initializer = true:warning
 dotnet_style_collection_initializer = true:warning
 
-# Meziantou rules — note: no rule exists to enforce global-only usings
-# MA0074 fires on xunit's Assert.Contains(string, string), which has no StringComparison overload — suppress
+# Collection expression preferences - Use collection expressions [] instead of new List<T>()
+dotnet_style_prefer_collection_expression = true:warning
+dotnet_style_prefer_collection_expression_for_empty = true:warning
+dotnet_style_prefer_collection_expression_for_array = true:warning
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = always:warning
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:warning
+
+# Code quality rules
+dotnet_diagnostic.CA1711.severity = none     # We intentionally suffix enums with 'Enum' for clarity
+dotnet_diagnostic.CA1822.severity = warning  # Mark members as static when possible
+dotnet_diagnostic.CA1862.severity = warning  # Use StringComparison overloads instead of ToLower/ToUpper comparisons
+dotnet_diagnostic.IDE0051.severity = warning # Remove unused private members
+dotnet_diagnostic.IDE0290.severity = warning # Use primary constructors (C# 12+)
+dotnet_diagnostic.IDE0305.severity = warning # Use collection expression for fluent (.ToList() -> [...])
+
+# ReSharper/Rider specific settings
+resharper_arrange_redundant_parentheses_highlighting = hint
+resharper_arrange_this_qualifier_highlighting = hint
+resharper_arrange_type_member_modifiers_highlighting = hint
+resharper_arrange_type_modifiers_highlighting = hint
+resharper_built_in_type_reference_style_for_member_access_highlighting = hint
+resharper_built_in_type_reference_style_highlighting = hint
+resharper_redundant_base_qualifier_highlighting = warning
+resharper_arrange_var_keywords_in_deconstructing_declaration_highlighting = warning
+resharper_redundant_type_specification_in_default_expression_highlighting = warning
+resharper_redundant_explicit_array_size_highlighting = warning
+resharper_redundant_type_arguments_of_method_highlighting = warning
+
+# Code quality - member accessibility
+resharper_member_can_be_private_global_highlighting = warning
+resharper_member_can_be_made_static_global_highlighting = warning
+
+# Documentation quality
+resharper_missing_article_highlighting = warning
+
+# CA1708 (identifiers differing only by case) -- C# 14 extension blocks use 'extension(Type)' syntax
+# which triggers false positives when multiple extension blocks exist in the same file
+dotnet_diagnostic.CA1708.severity = none
+
+# Meziantou rules -- MA0074 fires on xunit's Assert.Contains(string, string), which has no StringComparison overload
 dotnet_diagnostic.MA0074.severity = none
+# MA0026 treats TODO comments as errors -- TODOs are valid technical debt markers
+dotnet_diagnostic.MA0026.severity = none
+# MA0004 (ConfigureAwait) -- ASP.NET Core apps have no SynchronizationContext, not applicable
+dotnet_diagnostic.MA0004.severity = none
+# MA0015 fires when ArgumentNullException.ThrowIfNull is used on fields/locals -- valid pattern
+dotnet_diagnostic.MA0015.severity = none
+# MA0051 (method too long) -- OnModelCreating and test methods are legitimately long
+dotnet_diagnostic.MA0051.severity = none
 
 [*.{json,yml,yaml}]
 indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+
+# EF Core generates migration files with block-scoped namespaces -- suppress file-scoped namespace rule
+[**/Migrations/*.cs]
+csharp_style_namespace_declarations = block_scoped:none
+# CA1707 -- EF Core scaffold generates migration class names with underscores (e.g. 20240101_InitialCreate)
+dotnet_diagnostic.CA1707.severity = none
+# MA0048 -- EF Core scaffold generates the file name matching the class name; we don't control that
+dotnet_diagnostic.MA0048.severity = none
+# MA0051 -- Up()/Down() methods in migrations are legitimately long; splitting them would break EF tooling
+dotnet_diagnostic.MA0051.severity = none
+
+# Test projects use Method_Condition_Result naming convention -- suppress underscore warning
+# CA2201 -- tests use new Exception() to simulate errors in mock setups; this is intentional
+# CA1805 -- readonly fields in builder pattern are explicitly set to null for readability
+# CA1001 -- xUnit manages test class lifecycle; IDisposable pattern is verbose for test fixtures
+# CA1873 -- Arg.Any<>() in NSubstitute assertions triggers false positives for logger arg evaluation
+[**/*.Tests/**/*.cs]
+dotnet_diagnostic.CA1707.severity = none
+dotnet_diagnostic.CA2201.severity = none
+dotnet_diagnostic.CA1805.severity = none
+dotnet_diagnostic.CA1001.severity = none
+dotnet_diagnostic.CA1873.severity = none
+dotnet_diagnostic.MA0048.severity = none
+
+[**/*Tests*.cs]
+dotnet_diagnostic.CA1707.severity = none
+dotnet_diagnostic.CA2201.severity = none
+dotnet_diagnostic.CA1805.severity = none
+dotnet_diagnostic.CA1001.severity = none
+dotnet_diagnostic.CA1873.severity = none
+dotnet_diagnostic.MA0048.severity = none

--- a/skills/dotnet-minimal-api/template/AGENTS.md
+++ b/skills/dotnet-minimal-api/template/AGENTS.md
@@ -55,6 +55,12 @@ var result = items
     .Select(x => new ItemDto(x.Id, x.Name));
 ```
 
+## Locals
+
+Always use `var` for local variables. The editorconfig enforces
+`csharp_style_var_elsewhere = true:warning`, which combined with `TreatWarningsAsErrors` makes
+explicit types a build error for locals.
+
 ## Usings
 
 Never add `using` directives at the top of individual C# files. Always add them to `GlobalUsings.cs`

--- a/skills/dotnet-minimal-api/template/AGENTS.md
+++ b/skills/dotnet-minimal-api/template/AGENTS.md
@@ -9,7 +9,8 @@ alternatives.
 
 Always use extension blocks over extension methods. Lines must never exceed 80 characters. Each
 class must be in its own file. Prefer primary constructors over traditional constructors. Always use
-`init` over `set` for properties.
+`init` over `set` for properties. Always use `is null` and `is not null` instead of `== null` and
+`!= null`.
 
 For **record declarations**, each parameter must be on its own line with the opening parenthesis
 alone on the first line:

--- a/skills/dotnet-minimal-api/template/AGENTS.md
+++ b/skills/dotnet-minimal-api/template/AGENTS.md
@@ -11,13 +11,25 @@ Always use extension blocks over extension methods. Lines must never exceed 80 c
 class must be in its own file. Prefer primary constructors over traditional constructors. Always use
 `init` over `set` for properties.
 
-When declaring or calling with more than one parameter, each must be on its own line:
+For **record declarations**, each parameter must be on its own line with the opening parenthesis
+alone on the first line:
 
 ```csharp
 public record ItemDto(
     int Id,
     string Name,
     string Description);
+```
+
+For **method declarations and calls** with more than one parameter, the first parameter stays on the
+same line as the method name. Each additional parameter goes on its own line:
+
+```csharp
+public Task<ItemDto?> UpdateAsync(int id,
+    ItemDto item);
+
+logger.LogExceptionInMiddleware(ex.Message,
+    ex);
 ```
 
 For HTTP handler return types, expand generic type arguments onto separate indented lines:
@@ -27,7 +39,9 @@ private static async Task<
     Results<
         Ok<ItemDto>,
         NotFound>
-    > UpdateItem(
+    > UpdateItem(int id,
+    UpdateItemRequest request,
+    IItemService service)
 ```
 
 Method chaining is fine when each call is short and reads naturally. When chains are long, break

--- a/skills/dotnet-minimal-api/template/AGENTS.md
+++ b/skills/dotnet-minimal-api/template/AGENTS.md
@@ -1,0 +1,58 @@
+# Agent Instructions
+
+## Language and Framework
+
+This project uses C# 14 and .NET 10. Always prefer features from these versions over older
+alternatives.
+
+## Code Style
+
+Always use extension blocks over extension methods. Lines must never exceed 80 characters. Each
+class must be in its own file. Prefer primary constructors over traditional constructors. Always use
+`init` over `set` for properties.
+
+When declaring or calling with more than one parameter, each must be on its own line:
+
+```csharp
+public record ItemDto(
+    int Id,
+    string Name,
+    string Description);
+```
+
+For HTTP handler return types, expand generic type arguments onto separate indented lines:
+
+```csharp
+private static async Task<
+    Results<
+        Ok<ItemDto>,
+        NotFound>
+    > UpdateItem(
+```
+
+Method chaining is fine when each call is short and reads naturally. When chains are long, break
+each call onto its own line:
+
+```csharp
+var result = items
+    .Where(x => x.IsActive)
+    .OrderBy(x => x.Name)
+    .Select(x => new ItemDto(x.Id, x.Name));
+```
+
+## Usings
+
+Never add `using` directives at the top of individual C# files. Always add them to `GlobalUsings.cs`
+instead.
+
+## DTOs
+
+DTOs must be records and placed in the `Dtos` directory. Never use default parameter values in
+records. The multi-parameter rule applies — each property on its own line regardless of count:
+
+```csharp
+public record ItemDto(
+    int Id,
+    string Name,
+    string Description);
+```

--- a/skills/dotnet-minimal-api/template/CLAUDE.md
+++ b/skills/dotnet-minimal-api/template/CLAUDE.md
@@ -8,8 +8,8 @@ alternatives.
 ## Code Style
 
 Always use extension blocks over extension methods. Lines must never exceed 80 characters. Each
-class must be in its own file. Prefer primary constructors over traditional constructors. Always
-use `init` over `set` for properties.
+class must be in its own file. Prefer primary constructors over traditional constructors. Always use
+`init` over `set` for properties.
 
 When declaring or calling with more than one parameter, each must be on its own line:
 
@@ -40,11 +40,15 @@ var result = items
     .Select(x => new ItemDto(x.Id, x.Name));
 ```
 
+## Usings
+
+Never add `using` directives at the top of individual C# files. Always add them to `GlobalUsings.cs`
+instead.
+
 ## DTOs
 
-DTOs must be records and placed in the `Dtos` directory.
-Never use default parameter values in records. The multi-parameter rule applies — each
-property on its own line regardless of count:
+DTOs must be records and placed in the `Dtos` directory. Never use default parameter values in
+records. The multi-parameter rule applies — each property on its own line regardless of count:
 
 ```csharp
 public record ItemDto(

--- a/skills/dotnet-minimal-api/template/CLAUDE.md
+++ b/skills/dotnet-minimal-api/template/CLAUDE.md
@@ -41,7 +41,8 @@ var result = items
 
 ## DTOs
 
-DTOs must be records and placed in the `Dtos` directory. The multi-parameter rule applies — each
+DTOs must be records and placed in the `Dtos` directory.
+Never use default parameter values in records. The multi-parameter rule applies — each
 property on its own line regardless of count:
 
 ```csharp

--- a/skills/dotnet-minimal-api/template/CLAUDE.md
+++ b/skills/dotnet-minimal-api/template/CLAUDE.md
@@ -55,6 +55,12 @@ var result = items
     .Select(x => new ItemDto(x.Id, x.Name));
 ```
 
+## Locals
+
+Always use `var` for local variables. The editorconfig enforces
+`csharp_style_var_elsewhere = true:warning`, which combined with `TreatWarningsAsErrors` makes
+explicit types a build error for locals.
+
 ## Usings
 
 Never add `using` directives at the top of individual C# files. Always add them to `GlobalUsings.cs`

--- a/skills/dotnet-minimal-api/template/CLAUDE.md
+++ b/skills/dotnet-minimal-api/template/CLAUDE.md
@@ -8,7 +8,8 @@ alternatives.
 ## Code Style
 
 Always use extension blocks over extension methods. Lines must never exceed 80 characters. Each
-class must be in its own file. Prefer primary constructors over traditional constructors.
+class must be in its own file. Prefer primary constructors over traditional constructors. Always
+use `init` over `set` for properties.
 
 When declaring or calling with more than one parameter, each must be on its own line:
 

--- a/skills/dotnet-minimal-api/template/CLAUDE.md
+++ b/skills/dotnet-minimal-api/template/CLAUDE.md
@@ -9,7 +9,8 @@ alternatives.
 
 Always use extension blocks over extension methods. Lines must never exceed 80 characters. Each
 class must be in its own file. Prefer primary constructors over traditional constructors. Always use
-`init` over `set` for properties.
+`init` over `set` for properties. Always use `is null` and `is not null` instead of `== null` and
+`!= null`.
 
 For **record declarations**, each parameter must be on its own line with the opening parenthesis
 alone on the first line:

--- a/skills/dotnet-minimal-api/template/CLAUDE.md
+++ b/skills/dotnet-minimal-api/template/CLAUDE.md
@@ -2,10 +2,48 @@
 
 ## Language and Framework
 
-This project uses C# 14 and .NET 10. Always prefer features from these versions over older alternatives.
+This project uses C# 14 and .NET 10. Always prefer features
+from these versions over older alternatives.
 
 ## Code Style
 
 Always use extension blocks over extension methods.
 Lines must never exceed 80 characters.
 Each class must be in its own file.
+Prefer primary constructors over traditional constructors.
+
+Each property/parameter must be on its own line, regardless
+of count:
+
+```csharp
+public record ItemDto(
+    int Id,
+    string Name,
+    string Description);
+```
+
+For HTTP handler return types, expand generic type arguments
+onto separate indented lines:
+
+```csharp
+private static async Task<
+    Results<
+        Ok<ItemDto>,
+        NotFound>
+    > UpdateItem(
+```
+
+Method chaining is fine when each call is short and reads
+naturally. When chains are long, break each call onto its
+own line:
+
+```csharp
+var result = items
+    .Where(x => x.IsActive)
+    .OrderBy(x => x.Name)
+    .Select(x => new ItemDto(x.Id, x.Name));
+```
+
+## DTOs
+
+DTOs must be records and placed in the `Dtos` directory.

--- a/skills/dotnet-minimal-api/template/CLAUDE.md
+++ b/skills/dotnet-minimal-api/template/CLAUDE.md
@@ -11,13 +11,25 @@ Always use extension blocks over extension methods. Lines must never exceed 80 c
 class must be in its own file. Prefer primary constructors over traditional constructors. Always use
 `init` over `set` for properties.
 
-When declaring or calling with more than one parameter, each must be on its own line:
+For **record declarations**, each parameter must be on its own line with the opening parenthesis
+alone on the first line:
 
 ```csharp
 public record ItemDto(
     int Id,
     string Name,
     string Description);
+```
+
+For **method declarations and calls** with more than one parameter, the first parameter stays on the
+same line as the method name. Each additional parameter goes on its own line:
+
+```csharp
+public Task<ItemDto?> UpdateAsync(int id,
+    ItemDto item);
+
+logger.LogExceptionInMiddleware(ex.Message,
+    ex);
 ```
 
 For HTTP handler return types, expand generic type arguments onto separate indented lines:
@@ -27,7 +39,9 @@ private static async Task<
     Results<
         Ok<ItemDto>,
         NotFound>
-    > UpdateItem(
+    > UpdateItem(int id,
+    UpdateItemRequest request,
+    IItemService service)
 ```
 
 Method chaining is fine when each call is short and reads naturally. When chains are long, break

--- a/skills/dotnet-minimal-api/template/CLAUDE.md
+++ b/skills/dotnet-minimal-api/template/CLAUDE.md
@@ -2,18 +2,15 @@
 
 ## Language and Framework
 
-This project uses C# 14 and .NET 10. Always prefer features
-from these versions over older alternatives.
+This project uses C# 14 and .NET 10. Always prefer features from these versions over older
+alternatives.
 
 ## Code Style
 
-Always use extension blocks over extension methods.
-Lines must never exceed 80 characters.
-Each class must be in its own file.
-Prefer primary constructors over traditional constructors.
+Always use extension blocks over extension methods. Lines must never exceed 80 characters. Each
+class must be in its own file. Prefer primary constructors over traditional constructors.
 
-When declaring or calling with more than one parameter, each
-must be on its own line:
+When declaring or calling with more than one parameter, each must be on its own line:
 
 ```csharp
 public record ItemDto(
@@ -22,8 +19,7 @@ public record ItemDto(
     string Description);
 ```
 
-For HTTP handler return types, expand generic type arguments
-onto separate indented lines:
+For HTTP handler return types, expand generic type arguments onto separate indented lines:
 
 ```csharp
 private static async Task<
@@ -33,9 +29,8 @@ private static async Task<
     > UpdateItem(
 ```
 
-Method chaining is fine when each call is short and reads
-naturally. When chains are long, break each call onto its
-own line:
+Method chaining is fine when each call is short and reads naturally. When chains are long, break
+each call onto its own line:
 
 ```csharp
 var result = items
@@ -46,4 +41,12 @@ var result = items
 
 ## DTOs
 
-DTOs must be records and placed in the `Dtos` directory.
+DTOs must be records and placed in the `Dtos` directory. The multi-parameter rule applies — each
+property on its own line regardless of count:
+
+```csharp
+public record ItemDto(
+    int Id,
+    string Name,
+    string Description);
+```

--- a/skills/dotnet-minimal-api/template/CLAUDE.md
+++ b/skills/dotnet-minimal-api/template/CLAUDE.md
@@ -12,8 +12,8 @@ Lines must never exceed 80 characters.
 Each class must be in its own file.
 Prefer primary constructors over traditional constructors.
 
-Each property/parameter must be on its own line, regardless
-of count:
+When declaring or calling with more than one parameter, each
+must be on its own line:
 
 ```csharp
 public record ItemDto(

--- a/skills/dotnet-minimal-api/template/CLAUDE.md
+++ b/skills/dotnet-minimal-api/template/CLAUDE.md
@@ -1,0 +1,11 @@
+# Claude Instructions
+
+## Language and Framework
+
+This project uses C# 14 and .NET 10. Always prefer features from these versions over older alternatives.
+
+## Code Style
+
+Always use extension blocks over extension methods.
+Lines must never exceed 80 characters.
+Each class must be in its own file.

--- a/skills/dotnet-minimal-api/template/Directory.Packages.props
+++ b/skills/dotnet-minimal-api/template/Directory.Packages.props
@@ -13,6 +13,8 @@
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
 
+    <PackageVersion Include="Snapshooter.Xunit" Version="1.3.1" />
+
     <!-- Testing -->
     <!-- NOTE: coverlet.collector 8.0.0 and Microsoft.NET.Test.Sdk 18.3.0 include DLLs blocked by Windows WDAC
          policy on some machines. Keep at 6.0.4 and 17.14.1 until the policy is updated. -->

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/AppConfiguration.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/AppConfiguration.cs
@@ -6,7 +6,8 @@ public static class AppConfigurationExtensions
     {
         public void ConfigureApp()
         {
-            // Must be first — rewrites HttpContext with real client IP and scheme from proxy headers
+            // Must be first — rewrites HttpContext with real
+            // client IP and scheme from proxy headers
             app.UseForwardedHeaders();
 
             app.UseMiddleware<ExceptionMiddleware>();
@@ -15,19 +16,23 @@ public static class AppConfigurationExtensions
                 options.EnrichDiagnosticContext = EnrichWithClientIp;
             });
 
-            // ORDER MATTERS: UseCors must come before UseAuthentication/UseAuthorization
-            // so CORS preflight requests are handled before auth middleware runs.
+            // ORDER MATTERS: UseCors must come before
+            // UseAuthentication/UseAuthorization so that CORS
+            // preflight requests are handled before auth runs.
             if (app.Environment.IsDevelopment())
             {
                 app.UseCors("AllowLocalDevelopment");
             }
 
-            // ORDER MATTERS: UseAuthentication must come before UseAuthorization.
-            // Authentication establishes who the user is; authorization uses that identity.
+            // ORDER MATTERS: UseAuthentication must come
+            // before UseAuthorization.
+            // Authentication establishes who the user is;
+            // authorization uses that identity.
             app.UseAuthentication();
             app.UseAuthorization();
 
-            // Uncomment to enable rate limiting (must also enable in RegisterRateLimiting):
+            // Uncomment to enable rate limiting (must also
+            // enable in RegisterRateLimiting):
             app.UseRateLimiter();
 
             app.MapOpenApi();

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/AppConfiguration.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/AppConfiguration.cs
@@ -12,10 +12,7 @@ public static class AppConfigurationExtensions
             app.UseMiddleware<ExceptionMiddleware>();
             app.UseSerilogRequestLogging(options =>
             {
-                options.EnrichDiagnosticContext = (diagnosticContext, httpContext) =>
-                {
-                    diagnosticContext.Set("ClientIp", httpContext.Connection.RemoteIpAddress);
-                };
+                options.EnrichDiagnosticContext = EnrichWithClientIp;
             });
 
             // ORDER MATTERS: UseCors must come before UseAuthentication/UseAuthorization
@@ -50,4 +47,9 @@ public static class AppConfigurationExtensions
             app.ConfigureHttpRoutes();
         }
     }
+
+    internal static void EnrichWithClientIp(
+        IDiagnosticContext diagnosticContext,
+        HttpContext httpContext) =>
+        diagnosticContext.Set("ClientIp", httpContext.Connection.RemoteIpAddress);
 }

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/AppConfiguration.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/AppConfiguration.cs
@@ -34,14 +34,18 @@ public static class AppConfigurationExtensions
 
             // Health checks — map combined, liveness, and readiness probes
             app.MapHealthChecks("/health");
-            app.MapHealthChecks("/health/live", new HealthCheckOptions
-            {
-                Predicate = check => check.Tags.Contains("live")
-            });
-            app.MapHealthChecks("/health/ready", new HealthCheckOptions
-            {
-                Predicate = check => check.Tags.Contains("ready")
-            });
+            app.MapHealthChecks(
+                "/health/live",
+                new HealthCheckOptions
+                {
+                    Predicate = check => check.Tags.Contains("live")
+                });
+            app.MapHealthChecks(
+                "/health/ready",
+                new HealthCheckOptions
+                {
+                    Predicate = check => check.Tags.Contains("ready")
+                });
 
             // Feature endpoints
             app.ConfigureHttpRoutes();
@@ -51,5 +55,7 @@ public static class AppConfigurationExtensions
     internal static void EnrichWithClientIp(
         IDiagnosticContext diagnosticContext,
         HttpContext httpContext) =>
-        diagnosticContext.Set("ClientIp", httpContext.Connection.RemoteIpAddress);
+        diagnosticContext.Set(
+            "ClientIp",
+            httpContext.Connection.RemoteIpAddress);
 }

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/AppConfiguration.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/AppConfiguration.cs
@@ -34,14 +34,12 @@ public static class AppConfigurationExtensions
 
             // Health checks — map combined, liveness, and readiness probes
             app.MapHealthChecks("/health");
-            app.MapHealthChecks(
-                "/health/live",
+            app.MapHealthChecks("/health/live",
                 new HealthCheckOptions
                 {
                     Predicate = check => check.Tags.Contains("live")
                 });
-            app.MapHealthChecks(
-                "/health/ready",
+            app.MapHealthChecks("/health/ready",
                 new HealthCheckOptions
                 {
                     Predicate = check => check.Tags.Contains("ready")
@@ -55,7 +53,6 @@ public static class AppConfigurationExtensions
     internal static void EnrichWithClientIp(
         IDiagnosticContext diagnosticContext,
         HttpContext httpContext) =>
-        diagnosticContext.Set(
-            "ClientIp",
+        diagnosticContext.Set("ClientIp",
             httpContext.Connection.RemoteIpAddress);
 }

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/BuilderConfiguration.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/BuilderConfiguration.cs
@@ -47,13 +47,15 @@ public static class BuilderConfigurationExtensions
 
             builder.Services.AddCors(options =>
             {
-                options.AddPolicy("AllowLocalDevelopment", policy =>
-                {
-                    policy.WithOrigins(allowedOrigins)
-                        .AllowAnyHeader()
-                        .AllowAnyMethod()
-                        .AllowCredentials();
-                });
+                options.AddPolicy(
+                    "AllowLocalDevelopment",
+                    policy =>
+                    {
+                        policy.WithOrigins(allowedOrigins)
+                            .AllowAnyHeader()
+                            .AllowAnyMethod()
+                            .AllowCredentials();
+                    });
             });
         }
 
@@ -61,14 +63,18 @@ public static class BuilderConfigurationExtensions
         {
             builder.Services.AddRateLimiter(options =>
             {
-                options.AddFixedWindowLimiter("fixed", limiter =>
-                {
-                    limiter.PermitLimit = 100;
-                    limiter.Window = TimeSpan.FromSeconds(10);
-                    limiter.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
-                    limiter.QueueLimit = 10;
-                });
-                options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+                options.AddFixedWindowLimiter(
+                    "fixed",
+                    limiter =>
+                    {
+                        limiter.PermitLimit = 100;
+                        limiter.Window = TimeSpan.FromSeconds(10);
+                        limiter.QueueProcessingOrder =
+                            QueueProcessingOrder.OldestFirst;
+                        limiter.QueueLimit = 10;
+                    });
+                options.RejectionStatusCode =
+                    StatusCodes.Status429TooManyRequests;
             });
         }
 
@@ -77,29 +83,35 @@ public static class BuilderConfigurationExtensions
             builder.Services
                 .AddHealthChecks()
                 // Liveness: only checks if the process is running (used by Kubernetes liveness probe)
-                .AddCheck("live", () => HealthCheckResult.Healthy(), tags: ["live"]);
-                // Readiness: add dependency checks tagged "ready" for Kubernetes readiness probe. Examples:
-                // .AddSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")!)  // SQL Server connectivity (requires AspNetCore.HealthChecks.SqlServer)
-                // .AddNpgSql(builder.Configuration.GetConnectionString("DefaultConnection")!)     // PostgreSQL connectivity (requires AspNetCore.HealthChecks.NpgSql)
-                // .AddRedis(builder.Configuration.GetConnectionString("Redis")!)                  // Redis cache connectivity (requires AspNetCore.HealthChecks.Redis)
-                // .AddRabbitMQ(builder.Configuration.GetConnectionString("RabbitMQ")!)            // RabbitMQ message broker (requires AspNetCore.HealthChecks.RabbitMQ)
-                // .AddMongoDb(builder.Configuration.GetConnectionString("MongoDB")!)              // MongoDB connectivity (requires AspNetCore.HealthChecks.MongoDb)
-                // .AddCosmosDb(builder.Configuration.GetConnectionString("CosmosDb")!)            // Azure Cosmos DB connectivity (requires AspNetCore.HealthChecks.CosmosDb)
-                // .AddAzureServiceBusQueue(builder.Configuration.GetConnectionString("ServiceBus")!, "queue-name")  // Azure Service Bus queue (requires AspNetCore.HealthChecks.AzureServiceBus)
-                // .AddAzureBlobStorage(builder.Configuration.GetConnectionString("BlobStorage")!)   // Azure Blob Storage (requires AspNetCore.HealthChecks.AzureBlobStorage)
-                // .AddAzureQueueStorage(builder.Configuration.GetConnectionString("QueueStorage")!) // Azure Queue Storage (requires AspNetCore.HealthChecks.AzureStorage)
-                // .AddAzureKeyVault(new Uri(builder.Configuration["KeyVault:Uri"]!), new DefaultAzureCredential(), options => { }) // Azure Key Vault (requires AspNetCore.HealthChecks.AzureKeyVault)
-                // .AddUrlGroup(new Uri("https://external-service/health"), "external-service")    // External HTTP dependency reachability
-                // .AddProcessAllocatedMemoryHealthCheck(512);                                     // Fails if process exceeds 512 MB allocated memory
+                .AddCheck(
+                    "live",
+                    () => HealthCheckResult.Healthy(),
+                    tags: ["live"]);
+                    // Readiness: add dependency checks tagged "ready" for Kubernetes readiness probe. Examples:
+                    // .AddSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")!)  // SQL Server connectivity (requires AspNetCore.HealthChecks.SqlServer)
+                    // .AddNpgSql(builder.Configuration.GetConnectionString("DefaultConnection")!)     // PostgreSQL connectivity (requires AspNetCore.HealthChecks.NpgSql)
+                    // .AddRedis(builder.Configuration.GetConnectionString("Redis")!)                  // Redis cache connectivity (requires AspNetCore.HealthChecks.Redis)
+                    // .AddRabbitMQ(builder.Configuration.GetConnectionString("RabbitMQ")!)            // RabbitMQ message broker (requires AspNetCore.HealthChecks.RabbitMQ)
+                    // .AddMongoDb(builder.Configuration.GetConnectionString("MongoDB")!)              // MongoDB connectivity (requires AspNetCore.HealthChecks.MongoDb)
+                    // .AddCosmosDb(builder.Configuration.GetConnectionString("CosmosDb")!)            // Azure Cosmos DB connectivity (requires AspNetCore.HealthChecks.CosmosDb)
+                    // .AddAzureServiceBusQueue(builder.Configuration.GetConnectionString("ServiceBus")!, "queue-name")  // Azure Service Bus queue (requires AspNetCore.HealthChecks.AzureServiceBus)
+                    // .AddAzureBlobStorage(builder.Configuration.GetConnectionString("BlobStorage")!)   // Azure Blob Storage (requires AspNetCore.HealthChecks.AzureBlobStorage)
+                    // .AddAzureQueueStorage(builder.Configuration.GetConnectionString("QueueStorage")!) // Azure Queue Storage (requires AspNetCore.HealthChecks.AzureStorage)
+                    // .AddAzureKeyVault(new Uri(builder.Configuration["KeyVault:Uri"]!), new DefaultAzureCredential(), options => { }) // Azure Key Vault (requires AspNetCore.HealthChecks.AzureKeyVault)
+                    // .AddUrlGroup(new Uri("https://external-service/health"), "external-service")    // External HTTP dependency reachability
+                    // .AddProcessAllocatedMemoryHealthCheck(512);                                     // Fails if process exceeds 512 MB allocated memory
         }
 
-        public void RegisterProblemDetails() => builder.Services.AddProblemDetails();
+        public void RegisterProblemDetails() =>
+            builder.Services.AddProblemDetails();
 
         public void RegisterForwardedHeaders()
         {
             builder.Services.Configure<ForwardedHeadersOptions>(options =>
             {
-                options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+                options.ForwardedHeaders =
+                    ForwardedHeaders.XForwardedFor |
+                    ForwardedHeaders.XForwardedProto;
 
                 // Uncomment the lines below when ALL of the following are true:
                 //   - Running behind a reverse proxy (nginx, Kubernetes ingress, AWS ALB, Azure Front Door)

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/BuilderConfiguration.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/BuilderConfiguration.cs
@@ -47,8 +47,7 @@ public static class BuilderConfigurationExtensions
 
             builder.Services.AddCors(options =>
             {
-                options.AddPolicy(
-                    "AllowLocalDevelopment",
+                options.AddPolicy("AllowLocalDevelopment",
                     policy =>
                     {
                         policy.WithOrigins(allowedOrigins)
@@ -63,8 +62,7 @@ public static class BuilderConfigurationExtensions
         {
             builder.Services.AddRateLimiter(options =>
             {
-                options.AddFixedWindowLimiter(
-                    "fixed",
+                options.AddFixedWindowLimiter("fixed",
                     limiter =>
                     {
                         limiter.PermitLimit = 100;
@@ -83,8 +81,7 @@ public static class BuilderConfigurationExtensions
             builder.Services
                 .AddHealthChecks()
                 // Liveness: only checks if the process is running (used by Kubernetes liveness probe)
-                .AddCheck(
-                    "live",
+                .AddCheck("live",
                     () => HealthCheckResult.Healthy(),
                     tags: ["live"]);
                     // Readiness: add dependency checks tagged "ready" for Kubernetes readiness probe. Examples:

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/BuilderConfiguration.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/BuilderConfiguration.cs
@@ -27,12 +27,16 @@ public static class BuilderConfigurationExtensions
 
         public void RegisterAuthentication()
         {
-            // Uncomment and configure a scheme (e.g. JWT Bearer) to enable authentication:
-            // builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            // Uncomment and configure a scheme (e.g. JWT Bearer)
+            // to enable authentication:
+            // builder.Services.AddAuthentication(
+            //     JwtBearerDefaults.AuthenticationScheme)
             //     .AddJwtBearer(options =>
             //     {
-            //         options.Authority = builder.Configuration["Auth:Authority"];
-            //         options.Audience = builder.Configuration["Auth:Audience"];
+            //         options.Authority =
+            //             builder.Configuration["Auth:Authority"];
+            //         options.Audience =
+            //             builder.Configuration["Auth:Audience"];
             //     });
             builder.Services.AddAuthentication();
             builder.Services.AddAuthorization();
@@ -80,23 +84,68 @@ public static class BuilderConfigurationExtensions
         {
             builder.Services
                 .AddHealthChecks()
-                // Liveness: only checks if the process is running (used by Kubernetes liveness probe)
+                // Liveness: only checks if the process is running
+                // (used by Kubernetes liveness probe)
                 .AddCheck("live",
                     () => HealthCheckResult.Healthy(),
                     tags: ["live"]);
-                    // Readiness: add dependency checks tagged "ready" for Kubernetes readiness probe. Examples:
-                    // .AddSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")!)  // SQL Server connectivity (requires AspNetCore.HealthChecks.SqlServer)
-                    // .AddNpgSql(builder.Configuration.GetConnectionString("DefaultConnection")!)     // PostgreSQL connectivity (requires AspNetCore.HealthChecks.NpgSql)
-                    // .AddRedis(builder.Configuration.GetConnectionString("Redis")!)                  // Redis cache connectivity (requires AspNetCore.HealthChecks.Redis)
-                    // .AddRabbitMQ(builder.Configuration.GetConnectionString("RabbitMQ")!)            // RabbitMQ message broker (requires AspNetCore.HealthChecks.RabbitMQ)
-                    // .AddMongoDb(builder.Configuration.GetConnectionString("MongoDB")!)              // MongoDB connectivity (requires AspNetCore.HealthChecks.MongoDb)
-                    // .AddCosmosDb(builder.Configuration.GetConnectionString("CosmosDb")!)            // Azure Cosmos DB connectivity (requires AspNetCore.HealthChecks.CosmosDb)
-                    // .AddAzureServiceBusQueue(builder.Configuration.GetConnectionString("ServiceBus")!, "queue-name")  // Azure Service Bus queue (requires AspNetCore.HealthChecks.AzureServiceBus)
-                    // .AddAzureBlobStorage(builder.Configuration.GetConnectionString("BlobStorage")!)   // Azure Blob Storage (requires AspNetCore.HealthChecks.AzureBlobStorage)
-                    // .AddAzureQueueStorage(builder.Configuration.GetConnectionString("QueueStorage")!) // Azure Queue Storage (requires AspNetCore.HealthChecks.AzureStorage)
-                    // .AddAzureKeyVault(new Uri(builder.Configuration["KeyVault:Uri"]!), new DefaultAzureCredential(), options => { }) // Azure Key Vault (requires AspNetCore.HealthChecks.AzureKeyVault)
-                    // .AddUrlGroup(new Uri("https://external-service/health"), "external-service")    // External HTTP dependency reachability
-                    // .AddProcessAllocatedMemoryHealthCheck(512);                                     // Fails if process exceeds 512 MB allocated memory
+            // Readiness: add dependency checks tagged "ready"
+            // for Kubernetes readiness probe. Examples:
+            //
+            // SQL Server (AspNetCore.HealthChecks.SqlServer):
+            // .AddSqlServer(builder.Configuration
+            //     .GetConnectionString("DefaultConnection")!)
+            //
+            // PostgreSQL (AspNetCore.HealthChecks.NpgSql):
+            // .AddNpgSql(builder.Configuration
+            //     .GetConnectionString("DefaultConnection")!)
+            //
+            // Redis (AspNetCore.HealthChecks.Redis):
+            // .AddRedis(builder.Configuration
+            //     .GetConnectionString("Redis")!)
+            //
+            // RabbitMQ (AspNetCore.HealthChecks.RabbitMQ):
+            // .AddRabbitMQ(builder.Configuration
+            //     .GetConnectionString("RabbitMQ")!)
+            //
+            // MongoDB (AspNetCore.HealthChecks.MongoDb):
+            // .AddMongoDb(builder.Configuration
+            //     .GetConnectionString("MongoDB")!)
+            //
+            // Azure Cosmos DB (AspNetCore.HealthChecks.CosmosDb):
+            // .AddCosmosDb(builder.Configuration
+            //     .GetConnectionString("CosmosDb")!)
+            //
+            // Azure Service Bus
+            // (AspNetCore.HealthChecks.AzureServiceBus):
+            // .AddAzureServiceBusQueue(builder.Configuration
+            //     .GetConnectionString("ServiceBus")!,
+            //     "queue-name")
+            //
+            // Azure Blob Storage
+            // (AspNetCore.HealthChecks.AzureBlobStorage):
+            // .AddAzureBlobStorage(builder.Configuration
+            //     .GetConnectionString("BlobStorage")!)
+            //
+            // Azure Queue Storage
+            // (AspNetCore.HealthChecks.AzureStorage):
+            // .AddAzureQueueStorage(builder.Configuration
+            //     .GetConnectionString("QueueStorage")!)
+            //
+            // Azure Key Vault
+            // (AspNetCore.HealthChecks.AzureKeyVault):
+            // .AddAzureKeyVault(
+            //     new Uri(builder.Configuration["KeyVault:Uri"]!),
+            //     new DefaultAzureCredential(),
+            //     options => { })
+            //
+            // External HTTP dependency reachability:
+            // .AddUrlGroup(
+            //     new Uri("https://external-service/health"),
+            //     "external-service")
+            //
+            // Memory (fails if process exceeds 512 MB):
+            // .AddProcessAllocatedMemoryHealthCheck(512);
         }
 
         public void RegisterProblemDetails() =>
@@ -110,19 +159,31 @@ public static class BuilderConfigurationExtensions
                     ForwardedHeaders.XForwardedFor |
                     ForwardedHeaders.XForwardedProto;
 
-                // Uncomment the lines below when ALL of the following are true:
-                //   - Running behind a reverse proxy (nginx, Kubernetes ingress, AWS ALB, Azure Front Door)
-                //   - The proxy is the sole entry point (pods are not directly reachable from the internet)
-                //   - Traffic arrives from a non-loopback IP (e.g., Kubernetes ClusterIP, internal VPC address)
+                // Uncomment the lines below when ALL of the
+                // following are true:
+                //   - Running behind a reverse proxy
+                //     (nginx, Kubernetes ingress,
+                //     AWS ALB, Azure Front Door)
+                //   - The proxy is the sole entry point (pods are
+                //     not directly reachable from the internet)
+                //   - Traffic arrives from a non-loopback IP
+                //     (e.g., Kubernetes ClusterIP,
+                //     internal VPC address)
                 //
                 // Common scenarios:
-                //   - Kubernetes: ingress controller reaches pods via ClusterIP — not loopback, so headers
-                //     are ignored by default. Clearing these lets any in-cluster proxy forward headers.
-                //   - Docker Compose: nginx container forwards to app container via bridge network IP.
-                //   - Cloud load balancers: AWS ALB, Azure App Gateway, Cloudflare — all use non-loopback IPs.
+                //   - Kubernetes: ingress controller reaches pods
+                //     via ClusterIP — not loopback, so headers are
+                //     ignored by default. Clearing these lets any
+                //     in-cluster proxy forward headers.
+                //   - Docker Compose: nginx container forwards to
+                //     app container via bridge network IP.
+                //   - Cloud load balancers: AWS ALB, Azure App
+                //     Gateway, Cloudflare — all use non-loopback
+                //     IPs.
                 //
-                // Do NOT uncomment if pods/containers are directly reachable from the internet —
-                // an attacker could spoof X-Forwarded-For to fake their IP.
+                // Do NOT uncomment if pods/containers are directly
+                // reachable from the internet — an attacker could
+                // spoof X-Forwarded-For to fake their IP.
                 // options.KnownNetworks.Clear();
                 // options.KnownProxies.Clear();
             });
@@ -137,45 +198,65 @@ public static class BuilderConfigurationExtensions
             builder.Host.UseSerilog((ctx, config) =>
                 config.ReadFrom.Configuration(ctx.Configuration));
 
-            // Serilog is configured via the "Serilog" section in appsettings.json.
-            // Active sinks: Console + File (rolling daily, 10-day retention).
-            // To add more sinks, install the NuGet package and add to "Using" + "WriteTo" in appsettings.json:
+            // Serilog is configured via the "Serilog" section in
+            // appsettings.json.
+            // Active sinks: Console + File (rolling daily, 10-day
+            // retention).
+            // To add more sinks, install the NuGet package and add
+            // to "Using" + "WriteTo" in appsettings.json:
             //
             // Seq (local structured log server — great for development):
             //   Package : Serilog.Sinks.Seq
-            //   WriteTo : { "Name": "Seq", "Args": { "serverUrl": "http://localhost:5341" } }
+            //   WriteTo : { "Name": "Seq", "Args": {
+            //     "serverUrl": "http://localhost:5341" } }
             //
             // Azure Application Insights:
             //   Package : Serilog.Sinks.ApplicationInsights
-            //   WriteTo : { "Name": "ApplicationInsights", "Args": { "connectionString": "<connection-string>", "telemetryConverter": "Serilog.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights" } }
+            //   WriteTo : { "Name": "ApplicationInsights",
+            //     "Args": { "connectionString": "<conn-str>",
+            //       "telemetryConverter": "<see pkg docs>" } }
             //
             // Azure Blob Storage:
             //   Package : Serilog.Sinks.AzureBlobStorage
-            //   WriteTo : { "Name": "AzureBlobStorage", "Args": { "connectionString": "<connection-string>", "storageContainerName": "logs", "storageFileName": "api-.log" } }
+            //   WriteTo : { "Name": "AzureBlobStorage",
+            //     "Args": { "connectionString": "<conn-str>",
+            //       "storageContainerName": "logs",
+            //       "storageFileName": "api-.log" } }
             //
             // Azure Cosmos DB:
             //   Package : Serilog.Sinks.AzureCosmosDB
-            //   WriteTo : { "Name": "AzureCosmosDB", "Args": { "endpointUri": "<endpoint>", "authorizationKey": "<key>" } }
+            //   WriteTo : { "Name": "AzureCosmosDB",
+            //     "Args": { "endpointUri": "<endpoint>",
+            //       "authorizationKey": "<key>" } }
             //
             // Elasticsearch / Kibana (ELK stack):
             //   Package : Serilog.Sinks.Elasticsearch
-            //   WriteTo : { "Name": "Elasticsearch", "Args": { "nodeUris": "http://localhost:9200", "indexFormat": "api-{0:yyyy.MM.dd}" } }
+            //   WriteTo : { "Name": "Elasticsearch",
+            //     "Args": { "nodeUris": "http://localhost:9200",
+            //       "indexFormat": "api-{0:yyyy.MM.dd}" } }
             //
             // Grafana Loki:
             //   Package : Serilog.Sinks.Grafana.Loki
-            //   WriteTo : { "Name": "GrafanaLoki", "Args": { "uri": "http://localhost:3100" } }
+            //   WriteTo : { "Name": "GrafanaLoki",
+            //     "Args": { "uri": "http://localhost:3100" } }
             //
             // Datadog:
             //   Package : Serilog.Sinks.Datadog.Logs
-            //   WriteTo : { "Name": "DatadogLogs", "Args": { "apiKey": "<api-key>" } }
+            //   WriteTo : { "Name": "DatadogLogs",
+            //     "Args": { "apiKey": "<api-key>" } }
             //
             // SQL Server:
             //   Package : Serilog.Sinks.MSSqlServer
-            //   WriteTo : { "Name": "MSSqlServer", "Args": { "connectionString": "<connection-string>", "tableName": "Logs", "autoCreateSqlTable": true } }
+            //   WriteTo : { "Name": "MSSqlServer",
+            //     "Args": { "connectionString": "<conn-str>",
+            //       "tableName": "Logs",
+            //       "autoCreateSqlTable": true } }
             //
             // MongoDB:
             //   Package : Serilog.Sinks.MongoDB
-            //   WriteTo : { "Name": "MongoDB", "Args": { "databaseUrl": "<connection-string>", "collectionName": "logs" } }
+            //   WriteTo : { "Name": "MongoDB",
+            //     "Args": { "databaseUrl": "<conn-str>",
+            //       "collectionName": "logs" } }
         }
 
         public void RegisterDatabase()
@@ -184,14 +265,17 @@ public static class BuilderConfigurationExtensions
             //
             // Entity Framework Core (SQL Server):
             // builder.Services.AddDbContext<AppDbContext>(options =>
-            //     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+            //     options.UseSqlServer(builder.Configuration
+            //         .GetConnectionString("DefaultConnection")));
             //
             // Entity Framework Core (PostgreSQL):
             // builder.Services.AddDbContext<AppDbContext>(options =>
-            //     options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
+            //     options.UseNpgsql(builder.Configuration
+            //         .GetConnectionString("DefaultConnection")));
             //
             // Dapper — just register your connection factory:
-            // builder.Services.AddSingleton<IDbConnectionFactory, SqlConnectionFactory>();
+            // builder.Services.AddSingleton<
+            //     IDbConnectionFactory, SqlConnectionFactory>();
         }
 
         // Register feature services and repositories here

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/BuilderConfiguration.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Configuration/BuilderConfiguration.cs
@@ -40,7 +40,7 @@ public static class BuilderConfigurationExtensions
 
         public void RegisterCors()
         {
-            string[] allowedOrigins = builder
+            var allowedOrigins = builder
                 .Configuration
                 .GetSection("Cors:AllowedOrigins")
                 .Get<string[]>() ?? [];

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Dtos/CreateItemRequest.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Dtos/CreateItemRequest.cs
@@ -1,0 +1,5 @@
+namespace MyMinimalWebApp.Api.Dtos;
+
+public record CreateItemRequest(
+    [Required] string Name,
+    [Required] string Description);

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Dtos/UpdateItemRequest.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Dtos/UpdateItemRequest.cs
@@ -1,9 +1,5 @@
 namespace MyMinimalWebApp.Api.Dtos;
 
-public record CreateItemRequest(
-    [Required] string Name,
-    [Required] string Description);
-
 public record UpdateItemRequest(
     [Required] string Name,
     [Required] string Description);

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Endpoints/HttpRoutes.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Endpoints/HttpRoutes.cs
@@ -6,7 +6,7 @@ public static class HttpRoutesExtensions
     {
         public void ConfigureHttpRoutes()
         {
-            RouteGroupBuilder root = app.MapGroup("api");
+            var root = app.MapGroup("api");
 
             app.MapItemEndpoints(root);
         }

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Endpoints/ItemEndpoints.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Endpoints/ItemEndpoints.cs
@@ -6,7 +6,7 @@ public static class ItemEndpointExtensions
     {
         public void MapItemEndpoints(RouteGroupBuilder root)
         {
-            RouteGroupBuilder group = root
+            var group = root
                 .MapGroup("/items")
                 .WithTags("Items");
                 // Uncomment to require authentication for all endpoints in this group:
@@ -44,9 +44,10 @@ public static class ItemEndpointExtensions
         }
     }
 
+#pragma warning disable IDE0051
     private static async Task<Ok<IEnumerable<ItemDto>>> GetAllItems(IItemService service)
     {
-        IEnumerable<ItemDto> items = await service.GetAllAsync();
+        var items = await service.GetAllAsync();
         return TypedResults.Ok(items);
     }
 
@@ -54,7 +55,7 @@ public static class ItemEndpointExtensions
         int id,
         IItemService service)
     {
-        ItemDto? item = await service.GetByIdAsync(id);
+        var item = await service.GetByIdAsync(id);
         return item is null
             ? TypedResults.NotFound()
             : TypedResults.Ok(item);
@@ -65,7 +66,7 @@ public static class ItemEndpointExtensions
         IItemService service)
     {
         var item = new ItemDto(0, request.Name, request.Description);
-        ItemDto created = await service.CreateAsync(item);
+        var created = await service.CreateAsync(item);
         return TypedResults.Created($"/api/items/{created.Id}", created);
     }
 
@@ -75,7 +76,7 @@ public static class ItemEndpointExtensions
         IItemService service)
     {
         var item = new ItemDto(0, request.Name, request.Description);
-        ItemDto? updated = await service.UpdateAsync(id, item);
+        var updated = await service.UpdateAsync(id, item);
         return updated is null
             ? TypedResults.NotFound()
             : TypedResults.Ok(updated);
@@ -85,10 +86,11 @@ public static class ItemEndpointExtensions
         int id,
         IItemService service)
     {
-        bool deleted = await service.DeleteAsync(id);
+        var deleted = await service.DeleteAsync(id);
         return deleted
             ? TypedResults.NoContent()
             : TypedResults.NotFound();
     }
+#pragma warning restore IDE0051
 }
 

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Endpoints/ItemEndpoints.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Endpoints/ItemEndpoints.cs
@@ -9,9 +9,9 @@ public static class ItemEndpointExtensions
             var group = root
                 .MapGroup("/items")
                 .WithTags("Items");
-                // Uncomment to require authentication for all
-                // endpoints in this group:
-                // .RequireAuthorization();
+            // Uncomment to require authentication for all
+            // endpoints in this group:
+            // .RequireAuthorization();
 
             group.MapGet("/",
                     GetAllItems)

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Endpoints/ItemEndpoints.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Endpoints/ItemEndpoints.cs
@@ -13,13 +13,15 @@ public static class ItemEndpointExtensions
                 // endpoints in this group:
                 // .RequireAuthorization();
 
-            group.MapGet("/", GetAllItems)
+            group.MapGet("/",
+                    GetAllItems)
                 .WithName("ListItems")
                 .WithDisplayName("List Items")
                 .WithSummary("List all items")
                 .WithDescription("Returns all items in the system.");
 
-            group.MapGet("/{id:int}", GetItemById)
+            group.MapGet("/{id:int}",
+                    GetItemById)
                 .WithName("GetItem")
                 .WithDisplayName("Get Item")
                 .WithSummary("Get an item by ID")
@@ -27,14 +29,16 @@ public static class ItemEndpointExtensions
                     "Returns a single item matching the given ID, " +
                     "or 404 if not found.");
 
-            group.MapPost("/", CreateItem)
+            group.MapPost("/",
+                    CreateItem)
                 .WithName("CreateItem")
                 .WithDisplayName("Create Item")
                 .WithSummary("Create a new item")
                 .WithDescription(
                     "Creates a new item and returns the created resource.");
 
-            group.MapPut("/{id:int}", UpdateItem)
+            group.MapPut("/{id:int}",
+                    UpdateItem)
                 .WithName("UpdateItem")
                 .WithDisplayName("Update Item")
                 .WithSummary("Update an item")
@@ -42,7 +46,8 @@ public static class ItemEndpointExtensions
                     "Updates an existing item by ID, " +
                     "or returns 404 if not found.");
 
-            group.MapDelete("/{id:int}", DeleteItem)
+            group.MapDelete("/{id:int}",
+                    DeleteItem)
                 .WithName("DeleteItem")
                 .WithDisplayName("Delete Item")
                 .WithSummary("Delete an item")
@@ -64,8 +69,7 @@ public static class ItemEndpointExtensions
         Results<
             Ok<ItemDto>,
             NotFound>
-        > GetItemById(
-        int id,
+        > GetItemById(int id,
         IItemService service)
     {
         var item = await service.GetByIdAsync(id);
@@ -76,17 +80,14 @@ public static class ItemEndpointExtensions
 
     private static async Task<
         Created<ItemDto>
-        > CreateItem(
-        CreateItemRequest request,
+        > CreateItem(CreateItemRequest request,
         IItemService service)
     {
-        var item = new ItemDto(
-            0,
+        var item = new ItemDto(0,
             request.Name,
             request.Description);
         var created = await service.CreateAsync(item);
-        return TypedResults.Created(
-            $"/api/items/{created.Id}",
+        return TypedResults.Created($"/api/items/{created.Id}",
             created);
     }
 
@@ -94,17 +95,14 @@ public static class ItemEndpointExtensions
         Results<
             Ok<ItemDto>,
             NotFound>
-        > UpdateItem(
-        int id,
+        > UpdateItem(int id,
         UpdateItemRequest request,
         IItemService service)
     {
-        var item = new ItemDto(
-            0,
+        var item = new ItemDto(0,
             request.Name,
             request.Description);
-        var updated = await service.UpdateAsync(
-            id,
+        var updated = await service.UpdateAsync(id,
             item);
         return updated is null
             ? TypedResults.NotFound()
@@ -115,8 +113,7 @@ public static class ItemEndpointExtensions
         Results<
             NoContent,
             NotFound>
-        > DeleteItem(
-        int id,
+        > DeleteItem(int id,
         IItemService service)
     {
         var deleted = await service.DeleteAsync(id);

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Endpoints/ItemEndpoints.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Endpoints/ItemEndpoints.cs
@@ -9,7 +9,8 @@ public static class ItemEndpointExtensions
             var group = root
                 .MapGroup("/items")
                 .WithTags("Items");
-                // Uncomment to require authentication for all endpoints in this group:
+                // Uncomment to require authentication for all
+                // endpoints in this group:
                 // .RequireAuthorization();
 
             group.MapGet("/", GetAllItems)
@@ -22,36 +23,48 @@ public static class ItemEndpointExtensions
                 .WithName("GetItem")
                 .WithDisplayName("Get Item")
                 .WithSummary("Get an item by ID")
-                .WithDescription("Returns a single item matching the given ID, or 404 if not found.");
+                .WithDescription(
+                    "Returns a single item matching the given ID, " +
+                    "or 404 if not found.");
 
             group.MapPost("/", CreateItem)
                 .WithName("CreateItem")
                 .WithDisplayName("Create Item")
                 .WithSummary("Create a new item")
-                .WithDescription("Creates a new item and returns the created resource.");
+                .WithDescription(
+                    "Creates a new item and returns the created resource.");
 
             group.MapPut("/{id:int}", UpdateItem)
                 .WithName("UpdateItem")
                 .WithDisplayName("Update Item")
                 .WithSummary("Update an item")
-                .WithDescription("Updates an existing item by ID, or returns 404 if not found.");
+                .WithDescription(
+                    "Updates an existing item by ID, " +
+                    "or returns 404 if not found.");
 
             group.MapDelete("/{id:int}", DeleteItem)
                 .WithName("DeleteItem")
                 .WithDisplayName("Delete Item")
                 .WithSummary("Delete an item")
-                .WithDescription("Deletes an item by ID, or returns 404 if not found.");
+                .WithDescription(
+                    "Deletes an item by ID, or returns 404 if not found.");
         }
     }
 
 #pragma warning disable IDE0051
-    private static async Task<Ok<IEnumerable<ItemDto>>> GetAllItems(IItemService service)
+    private static async Task<
+        Ok<IEnumerable<ItemDto>>
+        > GetAllItems(IItemService service)
     {
         var items = await service.GetAllAsync();
         return TypedResults.Ok(items);
     }
 
-    private static async Task<Results<Ok<ItemDto>, NotFound>> GetItemById(
+    private static async Task<
+        Results<
+            Ok<ItemDto>,
+            NotFound>
+        > GetItemById(
         int id,
         IItemService service)
     {
@@ -61,28 +74,48 @@ public static class ItemEndpointExtensions
             : TypedResults.Ok(item);
     }
 
-    private static async Task<Created<ItemDto>> CreateItem(
+    private static async Task<
+        Created<ItemDto>
+        > CreateItem(
         CreateItemRequest request,
         IItemService service)
     {
-        var item = new ItemDto(0, request.Name, request.Description);
+        var item = new ItemDto(
+            0,
+            request.Name,
+            request.Description);
         var created = await service.CreateAsync(item);
-        return TypedResults.Created($"/api/items/{created.Id}", created);
+        return TypedResults.Created(
+            $"/api/items/{created.Id}",
+            created);
     }
 
-    private static async Task<Results<Ok<ItemDto>, NotFound>> UpdateItem(
+    private static async Task<
+        Results<
+            Ok<ItemDto>,
+            NotFound>
+        > UpdateItem(
         int id,
         UpdateItemRequest request,
         IItemService service)
     {
-        var item = new ItemDto(0, request.Name, request.Description);
-        var updated = await service.UpdateAsync(id, item);
+        var item = new ItemDto(
+            0,
+            request.Name,
+            request.Description);
+        var updated = await service.UpdateAsync(
+            id,
+            item);
         return updated is null
             ? TypedResults.NotFound()
             : TypedResults.Ok(updated);
     }
 
-    private static async Task<Results<NoContent, NotFound>> DeleteItem(
+    private static async Task<
+        Results<
+            NoContent,
+            NotFound>
+        > DeleteItem(
         int id,
         IItemService service)
     {

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/GlobalUsings.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/GlobalUsings.cs
@@ -1,17 +1,21 @@
+global using System.ComponentModel.DataAnnotations;
+global using System.Threading.RateLimiting;
+
 global using Microsoft.AspNetCore.Diagnostics.HealthChecks;
-global using Microsoft.AspNetCore.HttpOverrides;
 global using Microsoft.AspNetCore.Http.HttpResults;
+global using Microsoft.AspNetCore.HttpOverrides;
 global using Microsoft.AspNetCore.RateLimiting;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Diagnostics.HealthChecks;
+
 global using MyMinimalWebApp.Api.Configuration;
 global using MyMinimalWebApp.Api.Dtos;
 global using MyMinimalWebApp.Api.Endpoints;
 global using MyMinimalWebApp.Api.Logging;
 global using MyMinimalWebApp.Api.Middleware;
 global using MyMinimalWebApp.Api.Services;
+
 global using Serilog;
-global using System.ComponentModel.DataAnnotations;
-global using System.Threading.RateLimiting;
+
 global using ILogger = Microsoft.Extensions.Logging.ILogger;
 global using SerilogLogger = Serilog.ILogger;

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Logging/Log.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Logging/Log.cs
@@ -6,8 +6,7 @@ internal static partial class Log
         EventId = 1001,
         Level = LogLevel.Error,
         Message = "Unhandled exception in request: {Message}")]
-    internal static partial void LogExceptionInMiddleware(
-        this ILogger logger,
+    internal static partial void LogExceptionInMiddleware(this ILogger logger,
         string message,
         Exception exception);
 }

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Middleware/ExceptionMiddleware.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Middleware/ExceptionMiddleware.cs
@@ -1,7 +1,6 @@
 namespace MyMinimalWebApp.Api.Middleware;
 
-public class ExceptionMiddleware(
-    RequestDelegate next,
+public class ExceptionMiddleware(RequestDelegate next,
     ILogger<ExceptionMiddleware> logger)
 {
     public async Task InvokeAsync(HttpContext context)
@@ -12,7 +11,8 @@ public class ExceptionMiddleware(
         }
         catch (Exception ex)
         {
-            logger.LogExceptionInMiddleware(ex.Message, ex);
+            logger.LogExceptionInMiddleware(ex.Message,
+                ex);
             await HandleExceptionAsync(context);
         }
     }

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Program.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Program.cs
@@ -1,7 +1,7 @@
-WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+var builder = WebApplication.CreateBuilder(args);
 builder.ConfigureBuilder();
 
-WebApplication app = builder.Build();
+var app = builder.Build();
 app.ConfigureApp();
 app.Run();
 

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Services/IItemService.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Services/IItemService.cs
@@ -5,8 +5,7 @@ public interface IItemService
     public Task<IEnumerable<ItemDto>> GetAllAsync();
     public Task<ItemDto?> GetByIdAsync(int id);
     public Task<ItemDto> CreateAsync(ItemDto item);
-    public Task<ItemDto?> UpdateAsync(
-        int id,
+    public Task<ItemDto?> UpdateAsync(int id,
         ItemDto item);
     public Task<bool> DeleteAsync(int id);
 }

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Services/IItemService.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Services/IItemService.cs
@@ -2,11 +2,11 @@ namespace MyMinimalWebApp.Api.Services;
 
 public interface IItemService
 {
-    Task<IEnumerable<ItemDto>> GetAllAsync();
-    Task<ItemDto?> GetByIdAsync(int id);
-    Task<ItemDto> CreateAsync(ItemDto item);
-    Task<ItemDto?> UpdateAsync(
+    public Task<IEnumerable<ItemDto>> GetAllAsync();
+    public Task<ItemDto?> GetByIdAsync(int id);
+    public Task<ItemDto> CreateAsync(ItemDto item);
+    public Task<ItemDto?> UpdateAsync(
         int id,
         ItemDto item);
-    Task<bool> DeleteAsync(int id);
+    public Task<bool> DeleteAsync(int id);
 }

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Services/ItemService.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Services/ItemService.cs
@@ -4,8 +4,14 @@ public class ItemService : IItemService
 {
     private readonly List<ItemDto> _items =
     [
-        new ItemDto(1, "Item 1", "First item"),
-        new ItemDto(2, "Item 2", "Second item"),
+        new ItemDto(
+            1,
+            "Item 1",
+            "First item"),
+        new ItemDto(
+            2,
+            "Item 2",
+            "Second item"),
     ];
 
     private int _nextId = 3;
@@ -21,7 +27,10 @@ public class ItemService : IItemService
 
     public Task<ItemDto> CreateAsync(ItemDto item)
     {
-        var newItem = new ItemDto(_nextId++, item.Name, item.Description);
+        var newItem = new ItemDto(
+            _nextId++,
+            item.Name,
+            item.Description);
         _items.Add(newItem);
         return Task.FromResult(newItem);
     }
@@ -36,7 +45,10 @@ public class ItemService : IItemService
             return Task.FromResult<ItemDto?>(null);
         }
 
-        var updatedItem = new ItemDto(id, item.Name, item.Description);
+        var updatedItem = new ItemDto(
+            id,
+            item.Name,
+            item.Description);
         _items[index] = updatedItem;
         return Task.FromResult<ItemDto?>(updatedItem);
     }

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Services/ItemService.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Services/ItemService.cs
@@ -15,7 +15,7 @@ public class ItemService : IItemService
 
     public Task<ItemDto?> GetByIdAsync(int id)
     {
-        ItemDto? item = _items.FirstOrDefault(x => x.Id == id);
+        var item = _items.FirstOrDefault(x => x.Id == id);
         return Task.FromResult(item);
     }
 
@@ -30,9 +30,11 @@ public class ItemService : IItemService
         int id,
         ItemDto item)
     {
-        int index = _items.FindIndex(x => x.Id == id);
+        var index = _items.FindIndex(x => x.Id == id);
         if (index < 0)
+        {
             return Task.FromResult<ItemDto?>(null);
+        }
 
         var updatedItem = new ItemDto(id, item.Name, item.Description);
         _items[index] = updatedItem;
@@ -41,9 +43,11 @@ public class ItemService : IItemService
 
     public Task<bool> DeleteAsync(int id)
     {
-        ItemDto? item = _items.FirstOrDefault(x => x.Id == id);
+        var item = _items.FirstOrDefault(x => x.Id == id);
         if (item is null)
+        {
             return Task.FromResult(false);
+        }
 
         _items.Remove(item);
         return Task.FromResult(true);

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Services/ItemService.cs
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/Services/ItemService.cs
@@ -4,12 +4,10 @@ public class ItemService : IItemService
 {
     private readonly List<ItemDto> _items =
     [
-        new ItemDto(
-            1,
+        new ItemDto(1,
             "Item 1",
             "First item"),
-        new ItemDto(
-            2,
+        new ItemDto(2,
             "Item 2",
             "Second item"),
     ];
@@ -27,16 +25,14 @@ public class ItemService : IItemService
 
     public Task<ItemDto> CreateAsync(ItemDto item)
     {
-        var newItem = new ItemDto(
-            _nextId++,
+        var newItem = new ItemDto(_nextId++,
             item.Name,
             item.Description);
         _items.Add(newItem);
         return Task.FromResult(newItem);
     }
 
-    public Task<ItemDto?> UpdateAsync(
-        int id,
+    public Task<ItemDto?> UpdateAsync(int id,
         ItemDto item)
     {
         var index = _items.FindIndex(x => x.Id == id);
@@ -45,8 +41,7 @@ public class ItemService : IItemService
             return Task.FromResult<ItemDto?>(null);
         }
 
-        var updatedItem = new ItemDto(
-            id,
+        var updatedItem = new ItemDto(id,
             item.Name,
             item.Description);
         _items[index] = updatedItem;

--- a/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.json
+++ b/skills/dotnet-minimal-api/template/src/MyMinimalWebApp.Api/appsettings.json
@@ -32,8 +32,5 @@
       }
     }
   },
-  "AllowedHosts": "*",
-  "Cors": {
-    "AllowedOrigins": []
-  }
+  "AllowedHosts": "*"
 }

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Configuration/CorsConfigurationTests.cs
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Configuration/CorsConfigurationTests.cs
@@ -1,0 +1,15 @@
+namespace MyMinimalWebApp.Api.IntegrationTests.Configuration;
+
+public class CorsConfigurationTests(NoCorsFactory factory)
+    : IClassFixture<NoCorsFactory>
+{
+    private readonly HttpClient _client = factory.CreateClient();
+
+    [Fact]
+    public async Task App_StartsSuccessfully_WithoutCorsOrigins()
+    {
+        var response = await _client.GetAsync("/health");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Configuration/NoCorsFactory.cs
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Configuration/NoCorsFactory.cs
@@ -1,0 +1,9 @@
+namespace MyMinimalWebApp.Api.IntegrationTests.Configuration;
+
+public class NoCorsFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+    }
+}

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Configuration/SerilogEnrichmentTests.cs
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Configuration/SerilogEnrichmentTests.cs
@@ -11,6 +11,6 @@ public class SerilogEnrichmentTests
 
         AppConfigurationExtensions.EnrichWithClientIp(context, httpContext);
 
-        Assert.True(context.WasCalled);
+        Assert.Equal("ClientIp", context.LastPropertyName);
     }
 }

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Configuration/SerilogEnrichmentTests.cs
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Configuration/SerilogEnrichmentTests.cs
@@ -1,0 +1,16 @@
+namespace MyMinimalWebApp.Api.IntegrationTests.Configuration;
+
+public class SerilogEnrichmentTests
+{
+    [Fact]
+    public void EnrichWithClientIp_SetsClientIpOnDiagnosticContext()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Connection.RemoteIpAddress = System.Net.IPAddress.Loopback;
+        var context = new StubDiagnosticContext();
+
+        AppConfigurationExtensions.EnrichWithClientIp(context, httpContext);
+
+        Assert.True(context.WasCalled);
+    }
+}

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Configuration/StubDiagnosticContext.cs
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Configuration/StubDiagnosticContext.cs
@@ -1,0 +1,11 @@
+namespace MyMinimalWebApp.Api.IntegrationTests.Configuration;
+
+internal sealed class StubDiagnosticContext : IDiagnosticContext
+{
+    public bool WasCalled { get; private set; }
+
+    public void Set(string propertyName, object? value, bool destructureObjects = false)
+        => WasCalled = true;
+
+    public void SetException(Exception exception) { }
+}

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Configuration/StubDiagnosticContext.cs
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Configuration/StubDiagnosticContext.cs
@@ -2,10 +2,10 @@ namespace MyMinimalWebApp.Api.IntegrationTests.Configuration;
 
 internal sealed class StubDiagnosticContext : IDiagnosticContext
 {
-    public bool WasCalled { get; private set; }
+    public string? LastPropertyName { get; private set; }
 
     public void Set(string propertyName, object? value, bool destructureObjects = false)
-        => WasCalled = true;
+        => LastPropertyName = propertyName;
 
     public void SetException(Exception exception) { }
 }

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Endpoints/ItemEndpointsTests.cs
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Endpoints/ItemEndpointsTests.cs
@@ -71,7 +71,7 @@ public class ItemEndpointsTests(WebApplicationFactory<Program> factory)
     }
 
     [Fact]
-    public async Task CreateItem_WithoutName_ReturnsBadRequest()
+    public async Task CreateItem_WithEmptyName_ReturnsBadRequest()
     {
         // Arrange
         var request = new { name = "", description = "A new item" };
@@ -86,7 +86,7 @@ public class ItemEndpointsTests(WebApplicationFactory<Program> factory)
     }
 
     [Fact]
-    public async Task CreateItem_WithoutDescription_ReturnsBadRequest()
+    public async Task CreateItem_WithEmptyDescription_ReturnsBadRequest()
     {
         // Arrange
         var request = new { name = "New item", description = "" };
@@ -152,7 +152,7 @@ public class ItemEndpointsTests(WebApplicationFactory<Program> factory)
     }
 
     [Fact]
-    public async Task UpdateItem_WithoutName_ReturnsBadRequest()
+    public async Task UpdateItem_WithEmptyName_ReturnsBadRequest()
     {
         // Arrange
         var request = new { name = "", description = "Updated description" };

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Endpoints/ItemEndpointsTests.cs
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Endpoints/ItemEndpointsTests.cs
@@ -1,23 +1,19 @@
 namespace MyMinimalWebApp.Api.IntegrationTests.Endpoints;
 
-public class ItemEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
+public class ItemEndpointsTests(WebApplicationFactory<Program> factory)
+    : IClassFixture<WebApplicationFactory<Program>>
 {
-    private readonly HttpClient _client;
-
-    public ItemEndpointsTests(WebApplicationFactory<Program> factory)
-    {
-        _client = factory.CreateClient();
-    }
+    private readonly HttpClient _client = factory.CreateClient();
 
     [Fact]
     public async Task GetAllItems_ReturnsOkWithItems()
     {
         // Act
-        HttpResponseMessage response = await _client.GetAsync("/api/items");
+        var response = await _client.GetAsync("/api/items");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        IEnumerable<ItemDto>? items = await response.Content.ReadFromJsonAsync<IEnumerable<ItemDto>>();
+        var items = await response.Content.ReadFromJsonAsync<IEnumerable<ItemDto>>();
         Assert.NotNull(items);
         Assert.NotEmpty(items);
     }
@@ -26,19 +22,21 @@ public class ItemEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
     public async Task GetItemById_WithValidId_ReturnsOkWithItem()
     {
         // First get all items to find a valid ID
-        HttpResponseMessage getAllResponse = await _client.GetAsync("/api/items");
-        IEnumerable<ItemDto>? items = await getAllResponse.Content.ReadFromJsonAsync<IEnumerable<ItemDto>>();
-        int? itemId = items?.First().Id;
-        
+        var getAllResponse = await _client.GetAsync("/api/items");
+        var items = await getAllResponse.Content.ReadFromJsonAsync<IEnumerable<ItemDto>>();
+        var itemId = items?.First().Id;
+
         if (itemId == null)
+        {
             return;
+        }
 
         // Act
-        HttpResponseMessage response = await _client.GetAsync($"/api/items/{itemId}");
+        var response = await _client.GetAsync($"/api/items/{itemId}");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        ItemDto? item = await response.Content.ReadFromJsonAsync<ItemDto>();
+        var item = await response.Content.ReadFromJsonAsync<ItemDto>();
         Assert.NotNull(item);
         Assert.Equal(itemId, item.Id);
     }
@@ -47,7 +45,7 @@ public class ItemEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
     public async Task GetItemById_WithInvalidId_ReturnsNotFound()
     {
         // Act
-        HttpResponseMessage response = await _client.GetAsync("/api/items/999");
+        var response = await _client.GetAsync("/api/items/999");
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -60,11 +58,11 @@ public class ItemEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
         var request = new { name = "New item", description = "A new item" };
 
         // Act
-        HttpResponseMessage response = await _client.PostAsJsonAsync("/api/items", request);
+        var response = await _client.PostAsJsonAsync("/api/items", request);
 
         // Assert
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        ItemDto? item = await response.Content.ReadFromJsonAsync<ItemDto>();
+        var item = await response.Content.ReadFromJsonAsync<ItemDto>();
         Assert.NotNull(item);
         Assert.Equal("New item", item.Name);
         Assert.Equal("A new item", item.Description);
@@ -77,7 +75,7 @@ public class ItemEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
         var request = new { name = "", description = "A new item" };
 
         // Act
-        HttpResponseMessage response = await _client.PostAsJsonAsync("/api/items", request);
+        var response = await _client.PostAsJsonAsync("/api/items", request);
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -90,7 +88,7 @@ public class ItemEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
         var request = new { name = "New item", description = "" };
 
         // Act
-        HttpResponseMessage response = await _client.PostAsJsonAsync("/api/items", request);
+        var response = await _client.PostAsJsonAsync("/api/items", request);
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -100,22 +98,24 @@ public class ItemEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
     public async Task UpdateItem_WithValidRequest_ReturnsOkWithUpdatedItem()
     {
         // First get all items to find a valid ID
-        HttpResponseMessage getAllResponse = await _client.GetAsync("/api/items");
-        IEnumerable<ItemDto>? items = await getAllResponse.Content.ReadFromJsonAsync<IEnumerable<ItemDto>>();
-        int? itemId = items?.First().Id;
-        
+        var getAllResponse = await _client.GetAsync("/api/items");
+        var items = await getAllResponse.Content.ReadFromJsonAsync<IEnumerable<ItemDto>>();
+        var itemId = items?.First().Id;
+
         if (itemId == null)
+        {
             return;
+        }
 
         // Arrange
         var request = new { name = "Updated item", description = "Updated description" };
 
         // Act
-        HttpResponseMessage response = await _client.PutAsJsonAsync($"/api/items/{itemId}", request);
+        var response = await _client.PutAsJsonAsync($"/api/items/{itemId}", request);
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        ItemDto? item = await response.Content.ReadFromJsonAsync<ItemDto>();
+        var item = await response.Content.ReadFromJsonAsync<ItemDto>();
         Assert.NotNull(item);
         Assert.Equal("Updated item", item.Name);
         Assert.Equal("Updated description", item.Description);
@@ -128,7 +128,7 @@ public class ItemEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
         var request = new { name = "Updated item", description = "Updated description" };
 
         // Act
-        HttpResponseMessage response = await _client.PutAsJsonAsync("/api/items/999", request);
+        var response = await _client.PutAsJsonAsync("/api/items/999", request);
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
@@ -138,18 +138,20 @@ public class ItemEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
     public async Task UpdateItem_WithoutName_ReturnsBadRequest()
     {
         // First get all items to find a valid ID
-        HttpResponseMessage getAllResponse = await _client.GetAsync("/api/items");
-        IEnumerable<ItemDto>? items = await getAllResponse.Content.ReadFromJsonAsync<IEnumerable<ItemDto>>();
-        int? itemId = items?.First().Id;
-        
+        var getAllResponse = await _client.GetAsync("/api/items");
+        var items = await getAllResponse.Content.ReadFromJsonAsync<IEnumerable<ItemDto>>();
+        var itemId = items?.First().Id;
+
         if (itemId == null)
+        {
             return;
+        }
 
         // Arrange
         var request = new { name = "", description = "Updated description" };
 
         // Act
-        HttpResponseMessage response = await _client.PutAsJsonAsync($"/api/items/{itemId}", request);
+        var response = await _client.PutAsJsonAsync($"/api/items/{itemId}", request);
 
         // Assert
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
@@ -159,21 +161,23 @@ public class ItemEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
     public async Task DeleteItem_WithValidId_ReturnsNoContent()
     {
         // First, get all items to know what ID to delete
-        HttpResponseMessage getResponse = await _client.GetAsync("/api/items");
-        IEnumerable<ItemDto>? items = await getResponse.Content.ReadFromJsonAsync<IEnumerable<ItemDto>>();
-        ItemDto? itemToDelete = items?.First();
-        
+        var getResponse = await _client.GetAsync("/api/items");
+        var items = await getResponse.Content.ReadFromJsonAsync<IEnumerable<ItemDto>>();
+        var itemToDelete = items?.First();
+
         if (itemToDelete == null)
+        {
             return;
+        }
 
         // Act
-        HttpResponseMessage response = await _client.DeleteAsync($"/api/items/{itemToDelete.Id}");
+        var response = await _client.DeleteAsync($"/api/items/{itemToDelete.Id}");
 
         // Assert
         Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
 
         // Verify it's deleted
-        HttpResponseMessage getAfterDelete = await _client.GetAsync($"/api/items/{itemToDelete.Id}");
+        var getAfterDelete = await _client.GetAsync($"/api/items/{itemToDelete.Id}");
         Assert.Equal(HttpStatusCode.NotFound, getAfterDelete.StatusCode);
     }
 
@@ -181,7 +185,7 @@ public class ItemEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
     public async Task DeleteItem_WithInvalidId_ReturnsNotFound()
     {
         // Act
-        HttpResponseMessage response = await _client.DeleteAsync("/api/items/999");
+        var response = await _client.DeleteAsync("/api/items/999");
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Endpoints/ItemEndpointsTests.cs
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Endpoints/ItemEndpointsTests.cs
@@ -8,12 +8,12 @@ public class ItemEndpointsTests(WebApplicationFactory<Program> factory)
     [Fact]
     public async Task GetAllItems_ReturnsOkWithItems()
     {
-        // Act
         var response = await _client.GetAsync("/api/items");
 
-        // Assert
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var items = await response.Content.ReadFromJsonAsync<IEnumerable<ItemDto>>();
+        Assert.Equal(HttpStatusCode.OK,
+            response.StatusCode);
+        var items = await response.Content
+            .ReadFromJsonAsync<IEnumerable<ItemDto>>();
         Assert.NotNull(items);
         Assert.NotEmpty(items);
     }
@@ -21,34 +21,35 @@ public class ItemEndpointsTests(WebApplicationFactory<Program> factory)
     [Fact]
     public async Task GetItemById_WithValidId_ReturnsOkWithItem()
     {
-        // First get all items to find a valid ID
-        var getAllResponse = await _client.GetAsync("/api/items");
-        var items = await getAllResponse.Content.ReadFromJsonAsync<IEnumerable<ItemDto>>();
-        var itemId = items?.First().Id;
-
-        if (itemId == null)
+        // Arrange
+        var createRequest = new
         {
-            return;
-        }
+            name = "Test item",
+            description = "Test description"
+        };
+        var createResponse = await _client.PostAsJsonAsync("/api/items",
+            createRequest);
+        var created = await createResponse.Content
+            .ReadFromJsonAsync<ItemDto>();
 
         // Act
-        var response = await _client.GetAsync($"/api/items/{itemId}");
+        var response = await _client.GetAsync($"/api/items/{created!.Id}");
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var item = await response.Content.ReadFromJsonAsync<ItemDto>();
-        Assert.NotNull(item);
-        Assert.Equal(itemId, item.Id);
+        Assert.Equal(HttpStatusCode.OK,
+            response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Snapshot.Match(body,
+            matchOptions => matchOptions.IgnoreField("id"));
     }
 
     [Fact]
     public async Task GetItemById_WithInvalidId_ReturnsNotFound()
     {
-        // Act
         var response = await _client.GetAsync("/api/items/999");
 
-        // Assert
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound,
+            response.StatusCode);
     }
 
     [Fact]
@@ -58,14 +59,15 @@ public class ItemEndpointsTests(WebApplicationFactory<Program> factory)
         var request = new { name = "New item", description = "A new item" };
 
         // Act
-        var response = await _client.PostAsJsonAsync("/api/items", request);
+        var response = await _client.PostAsJsonAsync("/api/items",
+            request);
 
         // Assert
-        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
-        var item = await response.Content.ReadFromJsonAsync<ItemDto>();
-        Assert.NotNull(item);
-        Assert.Equal("New item", item.Name);
-        Assert.Equal("A new item", item.Description);
+        Assert.Equal(HttpStatusCode.Created,
+            response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Snapshot.Match(body,
+            matchOptions => matchOptions.IgnoreField("id"));
     }
 
     [Fact]
@@ -75,10 +77,12 @@ public class ItemEndpointsTests(WebApplicationFactory<Program> factory)
         var request = new { name = "", description = "A new item" };
 
         // Act
-        var response = await _client.PostAsJsonAsync("/api/items", request);
+        var response = await _client.PostAsJsonAsync("/api/items",
+            request);
 
         // Assert
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest,
+            response.StatusCode);
     }
 
     [Fact]
@@ -88,97 +92,104 @@ public class ItemEndpointsTests(WebApplicationFactory<Program> factory)
         var request = new { name = "New item", description = "" };
 
         // Act
-        var response = await _client.PostAsJsonAsync("/api/items", request);
+        var response = await _client.PostAsJsonAsync("/api/items",
+            request);
 
         // Assert
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest,
+            response.StatusCode);
     }
 
     [Fact]
     public async Task UpdateItem_WithValidRequest_ReturnsOkWithUpdatedItem()
     {
-        // First get all items to find a valid ID
-        var getAllResponse = await _client.GetAsync("/api/items");
-        var items = await getAllResponse.Content.ReadFromJsonAsync<IEnumerable<ItemDto>>();
-        var itemId = items?.First().Id;
-
-        if (itemId == null)
-        {
-            return;
-        }
-
         // Arrange
-        var request = new { name = "Updated item", description = "Updated description" };
+        var createRequest = new
+        {
+            name = "Original item",
+            description = "Original description"
+        };
+        var createResponse = await _client.PostAsJsonAsync("/api/items",
+            createRequest);
+        var created = await createResponse.Content
+            .ReadFromJsonAsync<ItemDto>();
+        var updateRequest = new
+        {
+            name = "Updated item",
+            description = "Updated description"
+        };
 
         // Act
-        var response = await _client.PutAsJsonAsync($"/api/items/{itemId}", request);
+        var response = await _client.PutAsJsonAsync(
+            $"/api/items/{created!.Id}",
+            updateRequest);
 
         // Assert
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var item = await response.Content.ReadFromJsonAsync<ItemDto>();
-        Assert.NotNull(item);
-        Assert.Equal("Updated item", item.Name);
-        Assert.Equal("Updated description", item.Description);
+        Assert.Equal(HttpStatusCode.OK,
+            response.StatusCode);
+        var body = await response.Content.ReadAsStringAsync();
+        Snapshot.Match(body,
+            matchOptions => matchOptions.IgnoreField("id"));
     }
 
     [Fact]
     public async Task UpdateItem_WithInvalidId_ReturnsNotFound()
     {
         // Arrange
-        var request = new { name = "Updated item", description = "Updated description" };
+        var request = new
+        {
+            name = "Updated item",
+            description = "Updated description"
+        };
 
         // Act
-        var response = await _client.PutAsJsonAsync("/api/items/999", request);
+        var response = await _client.PutAsJsonAsync("/api/items/999",
+            request);
 
         // Assert
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound,
+            response.StatusCode);
     }
 
     [Fact]
     public async Task UpdateItem_WithoutName_ReturnsBadRequest()
     {
-        // First get all items to find a valid ID
-        var getAllResponse = await _client.GetAsync("/api/items");
-        var items = await getAllResponse.Content.ReadFromJsonAsync<IEnumerable<ItemDto>>();
-        var itemId = items?.First().Id;
-
-        if (itemId == null)
-        {
-            return;
-        }
-
         // Arrange
         var request = new { name = "", description = "Updated description" };
 
         // Act
-        var response = await _client.PutAsJsonAsync($"/api/items/{itemId}", request);
+        var response = await _client.PutAsJsonAsync("/api/items/1",
+            request);
 
         // Assert
-        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest,
+            response.StatusCode);
     }
 
     [Fact]
     public async Task DeleteItem_WithValidId_ReturnsNoContent()
     {
-        // First, get all items to know what ID to delete
-        var getResponse = await _client.GetAsync("/api/items");
-        var items = await getResponse.Content.ReadFromJsonAsync<IEnumerable<ItemDto>>();
-        var itemToDelete = items?.First();
-
-        if (itemToDelete == null)
+        // Arrange
+        var createRequest = new
         {
-            return;
-        }
+            name = "Item to delete",
+            description = "Will be deleted"
+        };
+        var createResponse = await _client.PostAsJsonAsync("/api/items",
+            createRequest);
+        var created = await createResponse.Content
+            .ReadFromJsonAsync<ItemDto>();
 
         // Act
-        var response = await _client.DeleteAsync($"/api/items/{itemToDelete.Id}");
+        var response = await _client.DeleteAsync($"/api/items/{created!.Id}");
 
         // Assert
-        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
-
-        // Verify it's deleted
-        var getAfterDelete = await _client.GetAsync($"/api/items/{itemToDelete.Id}");
-        Assert.Equal(HttpStatusCode.NotFound, getAfterDelete.StatusCode);
+        Assert.Equal(HttpStatusCode.NoContent,
+            response.StatusCode);
+        var getAfterDelete = await _client
+            .GetAsync($"/api/items/{created.Id}");
+        Assert.Equal(HttpStatusCode.NotFound,
+            getAfterDelete.StatusCode);
     }
 
     [Fact]
@@ -188,6 +199,7 @@ public class ItemEndpointsTests(WebApplicationFactory<Program> factory)
         var response = await _client.DeleteAsync("/api/items/999");
 
         // Assert
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal(HttpStatusCode.NotFound,
+            response.StatusCode);
     }
 }

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Endpoints/__snapshots__/ItemEndpointsTests.CreateItem_WithValidRequest_ReturnsCreatedWithItem.snap
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Endpoints/__snapshots__/ItemEndpointsTests.CreateItem_WithValidRequest_ReturnsCreatedWithItem.snap
@@ -1,0 +1,1 @@
+﻿{"id":5,"name":"New item","description":"A new item"}

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Endpoints/__snapshots__/ItemEndpointsTests.GetItemById_WithValidId_ReturnsOkWithItem.snap
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Endpoints/__snapshots__/ItemEndpointsTests.GetItemById_WithValidId_ReturnsOkWithItem.snap
@@ -1,0 +1,1 @@
+﻿{"id":6,"name":"Test item","description":"Test description"}

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Endpoints/__snapshots__/ItemEndpointsTests.UpdateItem_WithValidRequest_ReturnsOkWithUpdatedItem.snap
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Endpoints/__snapshots__/ItemEndpointsTests.UpdateItem_WithValidRequest_ReturnsOkWithUpdatedItem.snap
@@ -1,0 +1,1 @@
+﻿{"id":4,"name":"Updated item","description":"Updated description"}

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/GlobalUsings.cs
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/GlobalUsings.cs
@@ -10,6 +10,7 @@ global using MyMinimalWebApp.Api.Configuration;
 global using MyMinimalWebApp.Api.Dtos;
 
 global using Serilog;
+
 global using Snapshooter.Xunit;
 
 [assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/GlobalUsings.cs
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/GlobalUsings.cs
@@ -10,5 +10,6 @@ global using MyMinimalWebApp.Api.Configuration;
 global using MyMinimalWebApp.Api.Dtos;
 
 global using Serilog;
+global using Snapshooter.Xunit;
 
 [assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/GlobalUsings.cs
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/GlobalUsings.cs
@@ -1,8 +1,14 @@
-global using Microsoft.AspNetCore.Builder;
-global using Microsoft.AspNetCore.Hosting;
-global using Microsoft.AspNetCore.Mvc.Testing;
-global using MyMinimalWebApp.Api.Dtos;
 global using System.Net;
 global using System.Net.Http.Json;
+
+global using Microsoft.AspNetCore.Builder;
+global using Microsoft.AspNetCore.Hosting;
+global using Microsoft.AspNetCore.Http;
+global using Microsoft.AspNetCore.Mvc.Testing;
+
+global using MyMinimalWebApp.Api.Configuration;
+global using MyMinimalWebApp.Api.Dtos;
+
+global using Serilog;
 
 [assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/GlobalUsings.cs
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/GlobalUsings.cs
@@ -4,3 +4,5 @@ global using Microsoft.AspNetCore.Mvc.Testing;
 global using MyMinimalWebApp.Api.Dtos;
 global using System.Net;
 global using System.Net.Http.Json;
+
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/HealthChecks/HealthCheckTests.cs
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/HealthChecks/HealthCheckTests.cs
@@ -8,7 +8,7 @@ public class HealthCheckTests(WebApplicationFactory<Program> factory)
     [Fact]
     public async Task Health_ReturnsHealthy()
     {
-        HttpResponseMessage response = await _client.GetAsync("/health");
+        var response = await _client.GetAsync("/health");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
@@ -16,7 +16,7 @@ public class HealthCheckTests(WebApplicationFactory<Program> factory)
     [Fact]
     public async Task HealthLive_ReturnsHealthy()
     {
-        HttpResponseMessage response = await _client.GetAsync("/health/live");
+        var response = await _client.GetAsync("/health/live");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
@@ -24,7 +24,7 @@ public class HealthCheckTests(WebApplicationFactory<Program> factory)
     [Fact]
     public async Task HealthReady_ReturnsHealthy()
     {
-        HttpResponseMessage response = await _client.GetAsync("/health/ready");
+        var response = await _client.GetAsync("/health/ready");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Middleware/ExceptionMiddlewareTests.cs
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Middleware/ExceptionMiddlewareTests.cs
@@ -1,6 +1,7 @@
 namespace MyMinimalWebApp.Api.IntegrationTests.Middleware;
 
-public class ExceptionMiddlewareTests(ThrowingAppFactory factory) : IClassFixture<ThrowingAppFactory>
+public class ExceptionMiddlewareTests(ThrowingAppFactory factory)
+    : IClassFixture<ThrowingAppFactory>
 {
     private readonly HttpClient _client = factory.CreateClient();
 
@@ -9,11 +10,12 @@ public class ExceptionMiddlewareTests(ThrowingAppFactory factory) : IClassFixtur
     {
         var response = await _client.GetAsync("/throw");
 
-        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
-        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
-
+        Assert.Equal(HttpStatusCode.InternalServerError,
+            response.StatusCode);
+        Assert.Equal("application/json",
+            response.Content.Headers.ContentType?.MediaType);
         var body = await response.Content.ReadAsStringAsync();
-        Assert.Contains("An error occurred while processing your request.", body);
-        Assert.Contains("500", body);
+        Snapshot.Match(body,
+            matchOptions => matchOptions.IgnoreField("traceId"));
     }
 }

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Middleware/ExceptionMiddlewareTests.cs
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Middleware/ExceptionMiddlewareTests.cs
@@ -1,23 +1,18 @@
 namespace MyMinimalWebApp.Api.IntegrationTests.Middleware;
 
-public class ExceptionMiddlewareTests : IClassFixture<ThrowingAppFactory>
+public class ExceptionMiddlewareTests(ThrowingAppFactory factory) : IClassFixture<ThrowingAppFactory>
 {
-    private readonly HttpClient _client;
-
-    public ExceptionMiddlewareTests(ThrowingAppFactory factory)
-    {
-        _client = factory.CreateClient();
-    }
+    private readonly HttpClient _client = factory.CreateClient();
 
     [Fact]
     public async Task UnhandledException_Returns500WithProblemDetails()
     {
-        HttpResponseMessage response = await _client.GetAsync("/throw");
+        var response = await _client.GetAsync("/throw");
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
         Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
 
-        string body = await response.Content.ReadAsStringAsync();
+        var body = await response.Content.ReadAsStringAsync();
         Assert.Contains("An error occurred while processing your request.", body);
         Assert.Contains("500", body);
     }

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Middleware/__snapshots__/ExceptionMiddlewareTests.UnhandledException_Returns500WithProblemDetails.snap
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/Middleware/__snapshots__/ExceptionMiddlewareTests.UnhandledException_Returns500WithProblemDetails.snap
@@ -1,0 +1,1 @@
+﻿{"type":"https://tools.ietf.org/html/rfc7231#section-6.6.1","title":"An error occurred while processing your request.","status":500,"traceId":"0HNKIN31FSQH5"}

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/MyMinimalWebApp.Api.IntegrationTests.csproj
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/MyMinimalWebApp.Api.IntegrationTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <ExcludeFromCodeCoverage>true</ExcludeFromCodeCoverage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/MyMinimalWebApp.Api.IntegrationTests.csproj
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/MyMinimalWebApp.Api.IntegrationTests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <ExcludeFromCodeCoverage>true</ExcludeFromCodeCoverage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/MyMinimalWebApp.Api.IntegrationTests.csproj
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/MyMinimalWebApp.Api.IntegrationTests.csproj
@@ -11,6 +11,7 @@
     </PackageReference>
     <PackageReference Include="Meziantou.Analyzer" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Snapshooter.Xunit" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/MyMinimalWebApp.Api.IntegrationTests.csproj
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.IntegrationTests/MyMinimalWebApp.Api.IntegrationTests.csproj
@@ -5,12 +5,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Meziantou.Analyzer" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.UnitTests/GlobalUsings.cs
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.UnitTests/GlobalUsings.cs
@@ -1,3 +1,5 @@
 global using Bogus;
 global using MyMinimalWebApp.Api.Dtos;
 global using MyMinimalWebApp.Api.Services;
+
+[assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.UnitTests/GlobalUsings.cs
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.UnitTests/GlobalUsings.cs
@@ -1,4 +1,5 @@
 global using Bogus;
+
 global using MyMinimalWebApp.Api.Dtos;
 global using MyMinimalWebApp.Api.Services;
 

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.UnitTests/MyMinimalWebApp.Api.UnitTests.csproj
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.UnitTests/MyMinimalWebApp.Api.UnitTests.csproj
@@ -6,12 +6,18 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" />
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Meziantou.Analyzer" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.UnitTests/MyMinimalWebApp.Api.UnitTests.csproj
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.UnitTests/MyMinimalWebApp.Api.UnitTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <ExcludeFromCodeCoverage>true</ExcludeFromCodeCoverage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.UnitTests/MyMinimalWebApp.Api.UnitTests.csproj
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.UnitTests/MyMinimalWebApp.Api.UnitTests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <ExcludeFromCodeCoverage>true</ExcludeFromCodeCoverage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.UnitTests/Services/ItemServiceTests.cs
+++ b/skills/dotnet-minimal-api/template/tests/MyMinimalWebApp.Api.UnitTests/Services/ItemServiceTests.cs
@@ -12,7 +12,7 @@ public class ItemServiceTests
     [Fact]
     public async Task GetAllAsync_ReturnsAllItems()
     {
-        IEnumerable<ItemDto> items = await _sut.GetAllAsync();
+        var items = await _sut.GetAllAsync();
 
         Assert.NotNull(items);
         Assert.NotEmpty(items);
@@ -22,9 +22,9 @@ public class ItemServiceTests
     public async Task GetByIdAsync_WithValidId_ReturnsItem()
     {
         var all = (await _sut.GetAllAsync()).ToList();
-        ItemDto target = all.First();
+        var target = all.First();
 
-        ItemDto? result = await _sut.GetByIdAsync(target.Id);
+        var result = await _sut.GetByIdAsync(target.Id);
 
         Assert.NotNull(result);
         Assert.Equal(target.Id, result.Id);
@@ -33,7 +33,7 @@ public class ItemServiceTests
     [Fact]
     public async Task GetByIdAsync_WithInvalidId_ReturnsNull()
     {
-        ItemDto? result = await _sut.GetByIdAsync(999);
+        var result = await _sut.GetByIdAsync(999);
 
         Assert.Null(result);
     }
@@ -41,16 +41,16 @@ public class ItemServiceTests
     [Fact]
     public async Task CreateAsync_AddsAndReturnsItem()
     {
-        ItemDto dto = _faker.Generate();
+        var dto = _faker.Generate();
 
-        ItemDto created = await _sut.CreateAsync(dto);
+        var created = await _sut.CreateAsync(dto);
 
         Assert.NotNull(created);
         Assert.Equal(dto.Name, created.Name);
         Assert.Equal(dto.Description, created.Description);
         Assert.True(created.Id > 0);
 
-        ItemDto? fetched = await _sut.GetByIdAsync(created.Id);
+        var fetched = await _sut.GetByIdAsync(created.Id);
         Assert.NotNull(fetched);
     }
 
@@ -58,10 +58,10 @@ public class ItemServiceTests
     public async Task UpdateAsync_WithValidId_UpdatesAndReturnsItem()
     {
         var all = (await _sut.GetAllAsync()).ToList();
-        ItemDto target = all.First();
-        ItemDto updated = _faker.Generate();
+        var target = all.First();
+        var updated = _faker.Generate();
 
-        ItemDto? result = await _sut.UpdateAsync(target.Id, updated);
+        var result = await _sut.UpdateAsync(target.Id, updated);
 
         Assert.NotNull(result);
         Assert.Equal(target.Id, result.Id);
@@ -72,9 +72,9 @@ public class ItemServiceTests
     [Fact]
     public async Task UpdateAsync_WithInvalidId_ReturnsNull()
     {
-        ItemDto dto = _faker.Generate();
+        var dto = _faker.Generate();
 
-        ItemDto? result = await _sut.UpdateAsync(999, dto);
+        var result = await _sut.UpdateAsync(999, dto);
 
         Assert.Null(result);
     }
@@ -83,21 +83,20 @@ public class ItemServiceTests
     public async Task DeleteAsync_WithValidId_RemovesAndReturnsTrue()
     {
         var all = (await _sut.GetAllAsync()).ToList();
-        ItemDto target = all.First();
+        var target = all.First();
 
-        bool deleted = await _sut.DeleteAsync(target.Id);
+        var deleted = await _sut.DeleteAsync(target.Id);
 
         Assert.True(deleted);
-        ItemDto? fetched = await _sut.GetByIdAsync(target.Id);
+        var fetched = await _sut.GetByIdAsync(target.Id);
         Assert.Null(fetched);
     }
 
     [Fact]
     public async Task DeleteAsync_WithInvalidId_ReturnsFalse()
     {
-        bool deleted = await _sut.DeleteAsync(999);
+        var deleted = await _sut.DeleteAsync(999);
 
         Assert.False(deleted);
     }
 }
-


### PR DESCRIPTION
## Summary
- Expand `.editorconfig` with comprehensive C# coding standards and diagnostic rules
- Add `CLAUDE.md` and `AGENTS.md` with detailed code style instructions for AI agents
- Update `SKILL.md` to accurately reflect the template's setup and conventions
- Apply all new code style rules consistently across source and test files
- Add Snapshooter for response body snapshot testing and achieve 100% code coverage
- Add tests for CORS configuration, Serilog enrichment, and exception middleware
- Fix `ExcludeFromCodeCoverage` to use an assembly attribute instead of a CSProj property
- Configure test tool package metadata (`IncludeAssets`/`PrivateAssets`) correctly

## Changes

### Configuration & Tooling
- Expanded `.editorconfig` with modern C# preferences, code quality rules, and ReSharper hints
- Added `Snapshooter.Xunit` for snapshot testing of HTTP response bodies
- Fixed `ExcludeFromCodeCoverage` — moved from CSProj property to assembly-level attribute
- Set `IncludeAssets`/`PrivateAssets` metadata on test tool packages

### Agent/AI Instructions
- Added `CLAUDE.md` and `AGENTS.md` with rules for C# 14/.NET 10 style (primary constructors, `init`, `is null`/`is not null`, `var`, `GlobalUsings.cs`, record/method formatting, DTO conventions)
- Fixed `SKILL.md` inaccuracies and aligned it with actual template behavior

### Source Code
- Applied all CLAUDE.md style rules across all source files (formatting, usings, constructors, properties)
- Split `ItemRequests.cs` into `CreateItemRequest.cs` and `UpdateItemRequest.cs`

### Tests
- Added `CorsConfigurationTests`, `SerilogEnrichmentTests`, and expanded `ExceptionMiddlewareTests`
- Added snapshot files for `CreateItem`, `GetItemById`, `UpdateItem`, and unhandled exception responses
- Strengthened existing tests and aligned all test code with coding standards

## Test plan
- [ ] Build passes with no warnings (`TreatWarningsAsErrors` is enabled)
- [ ] All unit tests pass
- [ ] All integration tests pass
- [ ] Code coverage is at 100%
- [ ] Snapshot files match expected response shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)