### PR TITLE
chore: update previously pinned packages to latest stable versions

### DIFF
--- a/skills/dotnet-minimal-api/template/Directory.Packages.props
+++ b/skills/dotnet-minimal-api/template/Directory.Packages.props
@@ -6,9 +6,7 @@
 
   <ItemGroup>
     <!-- API -->
-    <!-- NOTE: Microsoft.AspNetCore.OpenApi 10.0.3+ changes the compiled API DLL hash, which triggers a Windows
-         Application Control (WDAC) policy block on some machines. Keep at 10.0.0 until the policy is updated. -->
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
@@ -16,13 +14,11 @@
     <PackageVersion Include="Snapshooter.Xunit" Version="1.3.1" />
 
     <!-- Testing -->
-    <!-- NOTE: coverlet.collector 8.0.0 and Microsoft.NET.Test.Sdk 18.3.0 include DLLs blocked by Windows WDAC
-         policy on some machines. Keep at 6.0.4 and 17.14.1 until the policy is updated. -->
     <PackageVersion Include="Bogus" Version="35.6.5" />
     <PackageVersion Include="Meziantou.Analyzer" Version="3.0.44" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
## Summary
- `Microsoft.AspNetCore.OpenApi` 10.0.0 → 10.0.5
- `Microsoft.AspNetCore.Mvc.Testing` 10.0.0 → 10.0.5
- `coverlet.collector` 6.0.4 → 8.0.1
- `Microsoft.NET.Test.Sdk` 18.0.1 → 18.3.0

## Notes
These packages were previously pinned due to Windows WDAC policy blocks. The policy has since been updated — build succeeds and all 25 tests pass cleanly with the new versions.

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 25/25 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)